### PR TITLE
verify: add `--rows-per-second`, `--live-runs-per-second`, metrics

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -32,6 +32,7 @@ func Command() *cobra.Command {
 				MaxBackoff:     time.Second,
 				MaxRetries:     5,
 			},
+			RunsPerSecond: 0,
 		}
 		verifyLimitRowsPerSecond int
 	)
@@ -135,6 +136,12 @@ func Command() *cobra.Command {
 		"live",
 		false,
 		"enables live mode, which attempts to account for rows that can change in value by retrying them before marking them as an inconsistency",
+	)
+	cmd.PersistentFlags().IntVar(
+		&verifyLiveVerificationSettings.RunsPerSecond,
+		"live-runs-per-second",
+		verifyLiveVerificationSettings.RunsPerSecond,
+		"if set, sets a maximum number of attempts to reverify per second",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyLiveVerificationSettings.MaxBatchSize,

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -33,6 +33,7 @@ func Command() *cobra.Command {
 				MaxRetries:     5,
 			},
 		}
+		verifyLimitRowsPerSecond int
 	)
 
 	cmd := &cobra.Command{
@@ -78,6 +79,7 @@ func Command() *cobra.Command {
 				verify.WithContinuous(verifyContinuous, verifyContinuousPause),
 				verify.WithLive(verifyLive, verifyLiveVerificationSettings),
 				verify.WithDBFilter(cmdutil.TableFilter()),
+				verify.WithRowsPerSecond(verifyLimitRowsPerSecond),
 			); err != nil {
 				return errors.Wrapf(err, "error verifying")
 			}
@@ -103,6 +105,12 @@ func Command() *cobra.Command {
 		"row-batch-size",
 		20000,
 		"number of rows to get from a table at a time",
+	)
+	cmd.PersistentFlags().IntVar(
+		&verifyLimitRowsPerSecond,
+		"rows-per-second",
+		0,
+		"if set, maximum number of rows to read per second during scanning per shard",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&verifyFixup,

--- a/datamove/dataexport/dataexport.go
+++ b/datamove/dataexport/dataexport.go
@@ -93,6 +93,7 @@ func scanWithRowIterator(
 		c,
 		table,
 		100_000,
+		nil,
 	)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -17,11 +17,13 @@ require (
 	github.com/pingcap/tidb v1.1.0-beta.0.20211124132551-4a1b2e9fe5b5
 	github.com/pingcap/tidb/parser v0.0.0-20211124132551-4a1b2e9fe5b5
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.5.1
 	github.com/rs/zerolog v1.29.1
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/oauth2 v0.8.0
 	golang.org/x/sync v0.2.0
+	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324
 )
 
 require (
@@ -77,7 +79,6 @@ require (
 	github.com/pingcap/log v0.0.0-20210906054005-afc726e70354 // indirect
 	github.com/pingcap/tipb v0.0.0-20211105090418-71142a4d40e3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.5.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.9.1 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect

--- a/verify/rowverify/live_reverifier.go
+++ b/verify/rowverify/live_reverifier.go
@@ -56,6 +56,18 @@ var (
 		Name:      "live_reverified_rows",
 		Help:      "Number of rows that require reverification by the live reverifier.",
 	})
+	liveReverifyRemainingPKs = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "molt",
+		Subsystem: "verify",
+		Name:      "live_queued_pks",
+		Help:      "Number of rows that are queued by the live reverifier.",
+	})
+	liveReverifyRemainingBatches = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "molt",
+		Subsystem: "verify",
+		Name:      "live_queued_batches",
+		Help:      "Number of batches of rows that require the live reverifier.",
+	})
 )
 
 func newLiveReverifier(
@@ -110,6 +122,9 @@ func newLiveReverifier(
 					Int("num_pks", queue.numPKs).
 					Msgf("waiting for live reverifier to complete")
 			}
+			liveReverifyRemainingPKs.Set(float64(queue.numPKs))
+			liveReverifyRemainingBatches.Set(float64(len(queue.items)))
+
 			// By default, block until we get work.
 			var nextWorkCh <-chan time.Time = noTrafficChannel
 			if len(queue.items) > 0 {

--- a/verify/rowverify/live_reverifier_test.go
+++ b/verify/rowverify/live_reverifier_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lib/pq/oid"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 )
 
 func TestLiveReverifier(t *testing.T) {
@@ -190,6 +191,7 @@ func TestLiveReverifier(t *testing.T) {
 				conns,
 				TableShard{VerifiedTable: tbl},
 				evl,
+				rate.NewLimiter(rate.Inf, 1),
 			)
 			require.NoError(t, err)
 

--- a/verify/rowverify/rowverify.go
+++ b/verify/rowverify/rowverify.go
@@ -86,7 +86,7 @@ func VerifyRowsOnShard(
 	var liveReverifier *liveReverifier
 	if liveReverifySettings != nil {
 		var err error
-		liveReverifier, err = newLiveReverifier(ctx, logger, conns, table, rowEVL)
+		liveReverifier, err = newLiveReverifier(ctx, logger, conns, table, rowEVL, rate.NewLimiter(liveReverifySettings.rateLimit(), 1))
 		if err != nil {
 			return err
 		}

--- a/verify/rowverify/rowverify.go
+++ b/verify/rowverify/rowverify.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/molt/rowiterator"
 	"github.com/cockroachdb/molt/verify/inconsistency"
 	"github.com/rs/zerolog"
+	"golang.org/x/time/rate"
 )
 
 type rowStats struct {
@@ -54,6 +55,7 @@ func VerifyRowsOnShard(
 	reporter inconsistency.Reporter,
 	logger zerolog.Logger,
 	liveReverifySettings *LiveReverificationSettings,
+	rateLimiter *rate.Limiter,
 ) error {
 	var iterators [2]rowiterator.Iterator
 	for i, conn := range conns {
@@ -72,6 +74,7 @@ func VerifyRowsOnShard(
 				EndPKVals:   table.EndPKVals,
 			},
 			rowBatchSize,
+			rateLimiter,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "error initializing row iterator on %s", conn.ID())


### PR DESCRIPTION
verify: add `--rows-per-second`

This commit adds a `rows-per-second` flag, which if set, limits rows
scanned to that amount per shard.

verify: add `--live-runs-per-second`

Which enforces how often the live reverifier can go about reverifying a
batch.

rowverify: add metrics to live reverifier

