### PR TITLE
mysqlconv: add enum comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you expect data to change as you do data verification, you can use `--live`.
 This makes verifier re-check rows before marking them as problematic.
 
 ### Limitations
-* MySQL enums and set types are not supported.
+* MySQL set types are not supported.
 * Supports only comparing one MySQL database vs a whole CRDB schema (which is assumed to be "public").
 * Geospatial types cannot yet be compared.
 * We do not handle schema changes between commands well.

--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 	"github.com/go-sql-driver/mysql"
 	"github.com/jackc/pgx/v5"
@@ -109,6 +110,13 @@ func TestOnlyCleanDatabase(ctx context.Context, id ID, url string, dbName string
 func GetDataType(ctx context.Context, inConn Conn, oid oid.Oid) (*pgtype.Type, error) {
 	if typ, ok := inConn.TypeMap().TypeForOID(uint32(oid)); ok {
 		return typ, nil
+	}
+	if oid == types.AnyEnum.Oid() {
+		return &pgtype.Type{
+			Codec: &pgtype.EnumCodec{},
+			Name:  "enum",
+			OID:   uint32(oid),
+		}, nil
 	}
 	conn, ok := inConn.(*PGConn)
 	if !ok {

--- a/mysqlconv/data_type.go
+++ b/mysqlconv/data_type.go
@@ -6,7 +6,6 @@ import (
 )
 
 func DataTypeToOID(dataType, columnType string) oid.Oid {
-	// TODO: deal with enums.
 	switch dataType {
 	case "integer", "int", "mediumint":
 		return oid.T_int4
@@ -43,8 +42,7 @@ func DataTypeToOID(dataType, columnType string) oid.Oid {
 	case "json":
 		return oid.T_jsonb
 	case "enum":
-		// TODO: this is probably wrong, but leaving it for now.
-		return oid.T_text
+		return oid.T_anyenum
 	case "set":
 		panic(errors.Newf("enums not yet handled"))
 	default:

--- a/mysqlconv/data_type_test.go
+++ b/mysqlconv/data_type_test.go
@@ -51,7 +51,12 @@ WHERE table_schema = database() AND table_name = ? ORDER BY ORDINAL_POSITION`,
 					var dt string
 					var cn string
 					require.NoError(t, rows.Scan(&cn, &dt, &ct))
-					sb.WriteString(fmt.Sprintf("%s: %s\n", cn, types.OidToType[DataTypeToOID(dt, ct)].String()))
+					oid := DataTypeToOID(dt, ct)
+					str := fmt.Sprintf("(non-standard) %d", oid)
+					if typ, ok := types.OidToType[oid]; ok {
+						str = typ.String()
+					}
+					sb.WriteString(fmt.Sprintf("%s: %s\n", cn, str))
 				}
 				require.NoError(t, err)
 				return sb.String()

--- a/mysqlconv/datum_converter.go
+++ b/mysqlconv/datum_converter.go
@@ -49,6 +49,8 @@ func ConvertRowValue(typMap *pgtype.Map, val []byte, typOID oid.Oid) (tree.Datum
 		return tree.ParseDDecimal(string(val))
 	case pgtype.BitOID, pgtype.VarbitOID:
 		return tree.ParseDBitArray(string(val))
+	case oid.T_anyenum:
+		return tree.NewDString(string(val)), nil
 	}
 	return nil, errors.AssertionFailedf("value type OID %d not yet translatable", typOID)
 }

--- a/mysqlconv/testdata/datatype/datatype.ddt
+++ b/mysqlconv/testdata/datatype/datatype.ddt
@@ -13,7 +13,8 @@ CREATE TABLE da_test_table (
     float_test FLOAT,
     bigfloat_test DOUBLE,
     numeric_test DECIMAL,
-    qchar CHAR(30)
+    qchar CHAR(30),
+    enum_test ENUM('a', 'b', 'c')
 )
 ----
 tinyint_test: int2
@@ -30,3 +31,4 @@ float_test: float4
 bigfloat_test: float
 numeric_test: decimal
 qchar: varchar
+enum_test: (non-standard) 3500

--- a/verify/tableverify/tableverify.go
+++ b/verify/tableverify/tableverify.go
@@ -263,6 +263,9 @@ func comparableType(a, b *pgtype.Type) bool {
 	if a.Name == b.Name {
 		return true
 	}
+	if enumCodec(a) && enumCodec(b) {
+		return true
+	}
 	aTyp, ok := types.OidToType[oid.Oid(a.OID)]
 	if !ok {
 		return false
@@ -272,6 +275,11 @@ func comparableType(a, b *pgtype.Type) bool {
 		return false
 	}
 	return allowableTypes(oid.Oid(a.OID), oid.Oid(b.OID)) || aTyp.Equivalent(bTyp)
+}
+
+func enumCodec(a *pgtype.Type) bool {
+	_, ok := a.Codec.(*pgtype.EnumCodec)
+	return ok
 }
 
 func allowableTypes(a oid.Oid, b oid.Oid) bool {

--- a/verify/testdata/datadriven/mysql/enum.ddt
+++ b/verify/testdata/datadriven/mysql/enum.ddt
@@ -1,0 +1,30 @@
+exec source
+CREATE TABLE enum_table(id INT8 PRIMARY KEY, s ENUM('a', 'b'))
+----
+[mysql] 0 rows affected
+
+exec target
+CREATE TYPE enum_type AS ENUM('a', 'c')
+----
+[crdb] CREATE TYPE
+
+exec target
+CREATE TABLE enum_table(id INT8 PRIMARY KEY, s enum_type)
+----
+[crdb] CREATE TABLE
+
+exec source
+INSERT INTO enum_table VALUES (1, "a"), (2, "b")
+----
+[mysql] 2 rows affected
+
+exec target
+INSERT INTO enum_table VALUES (1, 'a'), (2, 'c')
+----
+[crdb] INSERT 0 2
+
+verify
+----
+{"level":"info","message":"starting verify on public.enum_table, shard 1/1"}
+{"level":"warn","table_schema":"public","table_name":"enum_table","source_values":{"s":"b"},"target_values":{"s":"c"},"primary_key":["2"],"message":"mismatching row value"}
+{"level":"info","message":"finished row verification on public.enum_table (shard 1/1): truth rows seen: 2, success: 1, missing: 0, mismatch: 1, extraneous: 0, live_retry: 0"}


### PR DESCRIPTION
This commit allows enum comparisons between MySQL enums and CRDB.