### PR TITLE
dataexport: automatically create a pg replication slot if requested 

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -13,3 +13,14 @@ services:
     ports:
       - 3306:3306
     command: --gtid-mode=on --enforce-gtid-consistency=on --binlog-row-metadata=full
+  postgresql:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: defaultdb
+    ports:
+      - 5432:5432
+    command:
+      - postgres
+      - -c
+      - wal_level=logical

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -9,31 +9,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-        ports:
-          - 5432:5432
-
-      # doesn't like cockroach-data not existing.
-     #cockroachdb:
-     #  image: cockroachdb/cockroach:latest-v22.2
-     #  ports:
-     #     - 26257:26257
-     #  options: >-
-     #     cockroachdb/cockroach:latest-v22.2 start-single-node --insecure --store type=mem,size=2G
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Start Databases
         working-directory: .github
-        run: docker-compose up -d cockroachdb mysql
+        run: docker-compose up -d cockroachdb mysql postgresql
 
       # Just cache based on job and go.sum contents.
       - name: Write cache key
@@ -46,12 +28,9 @@ jobs:
           cache: true
           cache-dependency-path: CACHE_KEY
 
-      - name: Setup test database
-        run: PGPASSWORD=postgres psql -U postgres -h localhost -c "CREATE DATABASE testdb"
-
       - name: Test
         run: |
-          POSTGRES_URL="postgres://postgres:postgres@localhost:5432/testdb" go test -race -v 2>&1 ./... | tee test_output.txt
+          go test -race -v 2>&1 ./... | tee test_output.txt
           go run github.com/jstemmer/go-junit-report -set-exit-code < test_output.txt > report.xml
 
       - name: Test Summary

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ need target data to be queriable during loading, which uses `COPY FROM` instead.
 
 Data can be truncated automatically if run with `--truncate`.
 
+A PG replication slot can be created for you if you use `pg-logical-replication-slot-name`,
+see `--help` for more related flags.
+
 For now, schemas must be identical on both sides. This is verified upfront -
 tables with mismatching columns may only be partially migrated.
 
@@ -161,15 +164,27 @@ molt fetch \
   --local-path-listen-addr '0.0.0.0:9005'
 ```
 
+Creating a replication slot with PG:
+```sh
+molt fetch \
+  --source 'postgres://postgres@localhost:5432/replicationload' \
+  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' \
+  --table-filter 'good_table' \
+  --local-path /tmp/basic \
+  --local-path-listen-addr '0.0.0.0:9005' \
+  --pg-logical-replication-slot-name 'hi_im_elfo' \
+  --pg-logical-replication-slot-decoding 'pgoutput'
+```
+
 ## Local Setup
 
 ### Running Tests
 * Ensure a local postgres instance is setup and can be logged in using
-  `postgres://postgres:postgres@localhost:5432/testdb` (this can be overriden with the
-  `POSTGRES_URL` env var):
+  `postgres://postgres:postgres@localhost:5432/defaultdb` (this can be
+  overridden with the `POSTGRES_URL` env var):
 ```sql
 CREATE USER 'postgres' PASSWORD 'postgres' ADMIN;
-CREATE DATABASE testdb;
+CREATE DATABASE defaultdb;
 ```
 * Ensure a local, insecure CockroachDB instance is setup
   (this can be overriden with the `COCKROACH_URL` env var):

--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -160,6 +160,24 @@ func Command() *cobra.Command {
 		100_000,
 		"how many rows to select at a time for the database",
 	)
+	cmd.PersistentFlags().StringVar(
+		&cfg.ExportSettings.PG.SlotName,
+		"pg-logical-replication-slot-name",
+		"",
+		"if set, the name of a replication slot that should be created before taking a snapshot of data",
+	)
+	cmd.PersistentFlags().StringVar(
+		&cfg.ExportSettings.PG.Plugin,
+		"pg-logical-replication-slot-plugin",
+		"pgoutput",
+		"if set, the output plugin used for logical replication under pg-logical-replication-slot-name",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&cfg.ExportSettings.PG.DropIfExists,
+		"pg-logical-replication-slot-drop-if-exists",
+		false,
+		"if set, drops the replication slot if it exists",
+	)
 	cmdutil.RegisterDBConnFlags(cmd)
 	cmdutil.RegisterLoggerFlags(cmd)
 	cmdutil.RegisterNameFilterFlags(cmd)

--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -154,6 +154,12 @@ func Command() *cobra.Command {
 		false,
 		"whether to truncate the table being imported to",
 	)
+	cmd.PersistentFlags().IntVar(
+		&cfg.ExportSettings.RowBatchSize,
+		"row-batch-size",
+		100_000,
+		"how many rows to select at a time for the database",
+	)
 	cmdutil.RegisterDBConnFlags(cmd)
 	cmdutil.RegisterLoggerFlags(cmd)
 	cmdutil.RegisterNameFilterFlags(cmd)

--- a/fetch/dataexport/crdb.go
+++ b/fetch/dataexport/crdb.go
@@ -15,6 +15,13 @@ type crdbSource struct {
 	conn dbconn.Conn
 }
 
+func NewCRDBSource(ctx context.Context, conn *dbconn.PGConn) (*crdbSource, error) {
+	return &crdbSource{
+		conn: conn,
+		aost: time.Now().UTC().Truncate(time.Second),
+	}, nil
+}
+
 func (c *crdbSource) CDCCursor() string {
 	return c.aost.Format(time.RFC3339Nano)
 }

--- a/fetch/dataexport/crdb.go
+++ b/fetch/dataexport/crdb.go
@@ -11,14 +11,18 @@ import (
 )
 
 type crdbSource struct {
-	aost time.Time
-	conn dbconn.Conn
+	aost     time.Time
+	settings Settings
+	conn     dbconn.Conn
 }
 
-func NewCRDBSource(ctx context.Context, conn *dbconn.PGConn) (*crdbSource, error) {
+func NewCRDBSource(
+	ctx context.Context, settings Settings, conn *dbconn.PGConn,
+) (*crdbSource, error) {
 	return &crdbSource{
-		conn: conn,
-		aost: time.Now().UTC().Truncate(time.Second),
+		conn:     conn,
+		settings: settings,
+		aost:     time.Now().UTC().Truncate(time.Second),
 	}, nil
 }
 
@@ -46,7 +50,7 @@ type crdbSourceConn struct {
 func (c *crdbSourceConn) Export(
 	ctx context.Context, writer io.Writer, table dbtable.VerifiedTable,
 ) error {
-	return scanWithRowIterator(ctx, c.conn, writer, rowiterator.ScanTable{
+	return scanWithRowIterator(ctx, c.src.settings, c.conn, writer, rowiterator.ScanTable{
 		Table: rowiterator.Table{
 			Name:              table.Name,
 			ColumnNames:       table.Columns,

--- a/fetch/dataexport/dataexport.go
+++ b/fetch/dataexport/dataexport.go
@@ -25,6 +25,8 @@ type SourceConn interface {
 
 type Settings struct {
 	RowBatchSize int
+
+	PG PGReplicationSlotSettings
 }
 
 func InferExportSource(ctx context.Context, settings Settings, conn dbconn.Conn) (Source, error) {

--- a/fetch/dataexport/dataexport.go
+++ b/fetch/dataexport/dataexport.go
@@ -3,16 +3,13 @@ package dataexport
 import (
 	"context"
 	"encoding/csv"
-	"fmt"
 	"io"
-	"time"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/molt/dbconn"
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/rowiterator"
-	"github.com/jackc/pgx/v5"
 )
 
 type Source interface {
@@ -30,56 +27,11 @@ func InferExportSource(ctx context.Context, conn dbconn.Conn) (Source, error) {
 	switch conn := conn.(type) {
 	case *dbconn.PGConn:
 		if conn.IsCockroach() {
-			return &crdbSource{
-				conn: conn,
-				aost: time.Now().UTC().Truncate(time.Second),
-			}, nil
+			return NewCRDBSource(ctx, conn)
 		}
-		// TODO: we should create a replication slot here.
-		var cdcCursor string
-		if err := conn.QueryRow(ctx, "SELECT pg_current_wal_insert_lsn()").Scan(&cdcCursor); err != nil {
-			return nil, errors.Wrap(err, "failed to export wal LSN")
-		}
-		// Keep tx with snapshot open to establish a consistent snapshot.
-		tx, err := conn.BeginTx(ctx, pgx.TxOptions{
-			IsoLevel:   pgx.RepeatableRead,
-			AccessMode: pgx.ReadOnly,
-		})
-		if err != nil {
-			return nil, err
-		}
-		var snapshotID string
-		if err := func() error {
-			if err := tx.QueryRow(ctx, "SELECT pg_export_snapshot()").Scan(&snapshotID); err != nil {
-				return errors.Wrap(err, "failed to export snapshot")
-			}
-			return nil
-		}(); err != nil {
-			return nil, errors.CombineErrors(err, tx.Rollback(ctx))
-		}
-		return &pgSource{
-			snapshotID: snapshotID,
-			cdcCursor:  cdcCursor,
-			tx:         tx,
-			conn:       conn,
-		}, nil
+		return NewPGSource(ctx, conn)
 	case *dbconn.MySQLConn:
-		var source string
-		var start, end int
-		if err := func() error {
-			if err := conn.QueryRowContext(ctx, "select source_uuid, min(interval_start), max(interval_end) from mysql.gtid_executed group by source_uuid").Scan(
-				&source, &start, &end,
-			); err != nil {
-				return errors.Wrap(err, "failed to export snapshot")
-			}
-			return nil
-		}(); err != nil {
-			return nil, err
-		}
-		return &mysqlSource{
-			gtid: fmt.Sprintf("%s:%d-%d", source, start, end),
-			conn: conn,
-		}, nil
+		return NewMySQLSource(ctx, conn)
 	}
 	return nil, errors.AssertionFailedf("unknown conn type: %T", conn)
 }

--- a/fetch/dataexport/pg.go
+++ b/fetch/dataexport/pg.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/fetch/internal/dataquery"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 type pgSource struct {
@@ -20,11 +21,34 @@ type pgSource struct {
 	cdcCursor  string
 }
 
+type PGReplicationSlotSettings struct {
+	SlotName     string
+	Plugin       string
+	DropIfExists bool
+}
+
 func NewPGSource(ctx context.Context, settings Settings, conn *dbconn.PGConn) (*pgSource, error) {
-	// TODO: we should create a replication slot here.
 	var cdcCursor string
-	if err := conn.QueryRow(ctx, "SELECT pg_current_wal_insert_lsn()").Scan(&cdcCursor); err != nil {
-		return nil, errors.Wrap(err, "failed to export wal LSN")
+	if settings.PG.SlotName != "" {
+		if settings.PG.DropIfExists {
+			if _, err := conn.Exec(ctx, "SELECT pg_drop_replication_slot($1)", settings.PG.SlotName); err != nil {
+				if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) && pgErr.Code != "42704" {
+					return nil, errors.Wrap(err, "error attempting to drop replication slot")
+				}
+			}
+		}
+		if err := conn.QueryRow(
+			ctx,
+			"SELECT lsn FROM pg_create_logical_replication_slot($1, $2)",
+			settings.PG.SlotName,
+			settings.PG.Plugin,
+		).Scan(&cdcCursor); err != nil {
+			return nil, errors.Wrap(err, "error creating replication slot")
+		}
+	} else {
+		if err := conn.QueryRow(ctx, "SELECT pg_current_wal_insert_lsn()").Scan(&cdcCursor); err != nil {
+			return nil, errors.Wrap(err, "failed to export wal LSN")
+		}
 	}
 	// Keep tx with snapshot open to establish a consistent snapshot.
 	tx, err := conn.BeginTx(ctx, pgx.TxOptions{

--- a/fetch/dataexport/pg_test.go
+++ b/fetch/dataexport/pg_test.go
@@ -1,0 +1,95 @@
+package dataexport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/molt/dbconn"
+	"github.com/cockroachdb/molt/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPGSource(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		prerun   func(t *testing.T, conn *dbconn.PGConn)
+		settings Settings
+		postrun  func(t *testing.T, conn *dbconn.PGConn)
+	}{
+		{
+			desc: "do not create replication slot",
+			settings: Settings{
+				RowBatchSize: 10,
+			},
+		},
+		{
+			desc: "create a replication slot",
+			settings: Settings{
+				RowBatchSize: 10,
+				PG: PGReplicationSlotSettings{
+					SlotName: "test_slot",
+					Plugin:   "pgoutput",
+				},
+			},
+			postrun: func(t *testing.T, conn *dbconn.PGConn) {
+				var n int
+				require.NoError(t, conn.QueryRow(
+					context.Background(),
+					"SELECT COUNT(1) FROM pg_replication_slots WHERE slot_name = $1 AND plugin = $2",
+					"test_slot",
+					"pgoutput",
+				).Scan(&n))
+				require.Equal(t, n, 1)
+			},
+		},
+		{
+			desc: "overwrites an existing replication slot",
+			settings: Settings{
+				RowBatchSize: 10,
+				PG: PGReplicationSlotSettings{
+					SlotName:     "test_slot",
+					Plugin:       "pgoutput",
+					DropIfExists: true,
+				},
+			},
+			prerun: func(t *testing.T, conn *dbconn.PGConn) {
+				_, err := conn.Exec(
+					context.Background(),
+					"SELECT pg_create_logical_replication_slot($1, $2)",
+					"test_slot",
+					"test_decoding",
+				)
+				require.NoError(t, err)
+			},
+			postrun: func(t *testing.T, conn *dbconn.PGConn) {
+				var n int
+				require.NoError(t, conn.QueryRow(
+					context.Background(),
+					"SELECT COUNT(1) FROM pg_replication_slots WHERE slot_name = $1 AND plugin = $2",
+					"test_slot",
+					"pgoutput",
+				).Scan(&n))
+				require.Equal(t, n, 1)
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			connRaw, err := dbconn.TestOnlyCleanDatabase(ctx, "pg", testutils.PGConnStr(), "pg_source_test")
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, connRaw.Close(ctx))
+			}()
+			conn := connRaw.(*dbconn.PGConn)
+			if tc.prerun != nil {
+				tc.prerun(t, conn)
+			}
+			s, err := NewPGSource(ctx, tc.settings, conn)
+			require.NoError(t, err)
+			if tc.postrun != nil {
+				tc.postrun(t, conn)
+			}
+			require.NoError(t, s.Close(ctx))
+		})
+	}
+}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -23,6 +23,8 @@ type Config struct {
 	Live        bool
 	Truncate    bool
 	Concurrency int
+
+	ExportSettings dataexport.Settings
 }
 
 func Fetch(
@@ -89,7 +91,7 @@ func Fetch(
 		return err
 	}
 	logger.Info().Msgf("establishing snapshot")
-	sqlSrc, err := dataexport.InferExportSource(ctx, conns[0])
+	sqlSrc, err := dataexport.InferExportSource(ctx, cfg.ExportSettings, conns[0])
 	if err != nil {
 		return err
 	}

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/molt/dbconn"
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
+	"github.com/cockroachdb/molt/fetch/dataexport"
 	"github.com/cockroachdb/molt/testutils"
 	"github.com/cockroachdb/molt/verify/dbverify"
 	"github.com/rs/zerolog"
@@ -86,7 +87,20 @@ func TestDataDriven(t *testing.T) {
 							require.NoError(t, err)
 						}
 
-						err = Fetch(ctx, Config{Live: live, Truncate: truncate}, logger, conns, src, filter)
+						err = Fetch(
+							ctx,
+							Config{
+								Live:     live,
+								Truncate: truncate,
+								ExportSettings: dataexport.Settings{
+									RowBatchSize: 2,
+								},
+							},
+							logger,
+							conns,
+							src,
+							filter,
+						)
 						if expectError {
 							require.Error(t, err)
 							return err.Error()

--- a/testutils/conn.go
+++ b/testutils/conn.go
@@ -13,7 +13,7 @@ import (
 )
 
 func PGConnStr() string {
-	pgInstanceURL := "postgres://postgres:postgres@localhost:5432/testdb"
+	pgInstanceURL := "postgres://postgres:postgres@127.0.0.1:5432/defaultdb"
 	if override, ok := os.LookupEnv("POSTGRES_URL"); ok {
 		pgInstanceURL = override
 	}


### PR DESCRIPTION
## fetch: move new dataexport creation methods to their individual files

## dataexport: make row batch size configurable

This commit ensures that `row-batch-size` is configurable when reading
rows from the database.

## dataexport: automatically create a pg replication slot if requested

This commit adds the ability for `fetch` to create a data replication
slot for later use.

