### PR TITLE
verify: add a --rows flag

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -35,6 +35,7 @@ func Command() *cobra.Command {
 			RunsPerSecond: 0,
 		}
 		verifyLimitRowsPerSecond int
+		verifyRows               bool
 	)
 
 	cmd := &cobra.Command{
@@ -81,6 +82,7 @@ func Command() *cobra.Command {
 				verify.WithLive(verifyLive, verifyLiveVerificationSettings),
 				verify.WithDBFilter(cmdutil.TableFilter()),
 				verify.WithRowsPerSecond(verifyLimitRowsPerSecond),
+				verify.WithRows(verifyRows),
 			); err != nil {
 				return errors.Wrapf(err, "error verifying")
 			}
@@ -136,6 +138,12 @@ func Command() *cobra.Command {
 		"live",
 		false,
 		"enables live mode, which attempts to account for rows that can change in value by retrying them before marking them as an inconsistency",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&verifyRows,
+		"rows",
+		true,
+		"whether rows should be verified (otherwise, performs a more basic schema check)",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyLiveVerificationSettings.RunsPerSecond,


### PR DESCRIPTION
This commit adds a `--rows` flag, which defaults to `true`. If disabled, this will disable any row based checks.

This is useful for tools like DMS verification, in which this ensures schemas match between the two sides.