### PR TITLE
dbconn: correctly pass in MySQL connection string

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -68,7 +68,7 @@ func Connect(ctx context.Context, preferredID ID, connStr string) (Conn, error) 
 		}
 		return ConnectPG(ctx, id, connStr)
 	case strings.Contains(before[0], "mysql"):
-		return ConnectMySQL(ctx, id, before[len(before)-1])
+		return ConnectMySQL(ctx, id, connStr)
 	case strings.Contains(before[0], "oracle"):
 		return ConnectOracle(ctx, id, connStr)
 	}


### PR DESCRIPTION
Previously, we omitted the `mysql://` part which was an artifact of the old parsing mechanism. fix that.