### PR TITLE
LMS: Add Helm Chart

### DIFF
--- a/charts/lms/Chart.yaml
+++ b/charts/lms/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: molt-lms
+description: Helm chart for MOLT Live Migration Service
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+icon: "https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png"

--- a/charts/lms/templates/_helpers.tpl
+++ b/charts/lms/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "molt-lms.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "molt-lms.fullname" -}}
+{{- if .Values.fullnameOverride }}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
+        {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+        {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "molt-lms.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "molt-lms.labels" -}}
+helm.sh/chart: {{ include "molt-lms.chart" . }}
+{{ include "molt-lms.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "molt-lms.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "molt-lms.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "molt-lms.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+    {{- default (include "molt-lms.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+    {{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/lms/templates/lms-deployment.yaml
+++ b/charts/lms/templates/lms-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.lms.releaseName }}
   {{- with .Values.lms.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -17,7 +16,6 @@ spec:
   selector:
     matchLabels:
       {{- include "molt-lms.selectorLabels" . | nindent 6 }}
-      release: {{ .Values.lms.releaseName }}
   template:
     metadata:
     {{- with .Values.lms.annotations }}
@@ -25,7 +23,6 @@ spec:
     {{- end }}
       labels:
         {{- include "molt-lms.selectorLabels" . | nindent 8 }}
-        release: {{ .Values.lms.releaseName }}
       {{- with .Values.lms.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}

--- a/charts/lms/templates/lms-deployment.yaml
+++ b/charts/lms/templates/lms-deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "molt-lms.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
+  {{- with .Values.lms.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.lms.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "molt-lms.selectorLabels" . | nindent 6 }}
+      release: {{ .Values.lms.releaseName }}
+  template:
+    metadata:
+    {{- with .Values.lms.annotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "molt-lms.selectorLabels" . | nindent 8 }}
+        release: {{ .Values.lms.releaseName }}
+      {{- with .Values.lms.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- with .Values.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "molt-lms.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: molt-lms
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args: [
+          "./molt-lms {{ .Values.lms.sourceDialect }}"
+          ]
+          env:
+            {{- if .Values.lms.configSecretName }}
+            - name: LMS_READ_CONFIG_FILE
+              value: "true"
+            {{- end }}
+            - name: LMS_SHADOW_MODE
+              value: {{ .Values.lms.shadowMode }}
+          {{- with .Values.lms.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: lms
+              containerPort: {{ .Values.lms.service.port }}
+            - name: metrics
+              containerPort: {{ .Values.lms.service.metricsPort }}
+          readinessProbe:
+            httpGet:
+              path: /vars
+              port: metrics
+          resources:
+            {{- toYaml .Values.lms.resources | nindent 12 }}
+      {{- if or .Values.lms.configSecretName .Values.lms.sslVolumes .Values.lms.sslVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.lms.configSecretName }}
+            - mountPath: "/app/configs"
+              name: {{ .Values.lms.configSecretName }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.lms.sslVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        {{- if .Values.lms.configSecretName }}
+        - name: {{ .Values.lms.configSecretName }}
+          secret:
+            secretName: {{ .Values.lms.configSecretName }}
+        {{- end }}
+        {{- with .Values.lms.sslVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end}}
+      {{- with .Values.lms.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lms/templates/lms-role.yaml
+++ b/charts/lms/templates/lms-role.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.lms.releaseName }}
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -25,7 +24,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.lms.releaseName }}
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/lms/templates/lms-role.yaml
+++ b/charts/lms/templates/lms-role.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lms-role
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+        - ""
+    resources:
+      - endpoints
+    verbs: ["get"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lms-rolebinding
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lms-role 
+subjects:
+- kind: ServiceAccount
+  name: {{ include "molt-lms.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}

--- a/charts/lms/templates/lms-service.yaml
+++ b/charts/lms/templates/lms-service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "molt-lms.fullname" . }}
+  namespace : {{ .Release.namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
+  {{- with .Values.lms.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.lms.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.lms.service.type }}
+  ports:
+    - port: {{ .Values.lms.service.port }}
+      name: lms
+      protocol: TCP
+    - port: {{ .Values.lms.service.metricsPort }}
+      name: metrics
+      protocol: TCP
+  selector:
+    {{- include "molt-lms.selectorLabels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
+  {{- with .Values.lms.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/lms/templates/lms-service.yaml
+++ b/charts/lms/templates/lms-service.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace : {{ .Release.namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.lms.releaseName }}
   {{- with .Values.lms.service.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -27,7 +26,6 @@ spec:
       protocol: TCP
   selector:
     {{- include "molt-lms.selectorLabels" . | nindent 4 }}
-    release: {{ .Values.lms.releaseName }}
   {{- with .Values.lms.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/lms/templates/lms-serviceMonitor.yaml
+++ b/charts/lms/templates/lms-serviceMonitor.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace : {{ .Release.namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.lms.releaseName }}
   {{- with .Values.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -21,7 +20,6 @@ spec:
   selector:
     matchLabels:
       {{- include "molt-lms.selectorLabels" . | nindent 6 }}
-      release: {{ .Values.lms.releaseName }}
     {{- with .Values.lms.service.labels }}
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/lms/templates/lms-serviceMonitor.yaml
+++ b/charts/lms/templates/lms-serviceMonitor.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "molt-lms.fullname" . }}
+  namespace : {{ .Release.namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
+  {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "molt-lms.selectorLabels" . | nindent 6 }}
+      release: {{ .Values.lms.releaseName }}
+    {{- with .Values.lms.service.labels }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.orchestrator.service.labels }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  namespaceSelector:
+  {{- if .Values.serviceMonitor.namespaced }}
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- else }}
+    any: true
+  {{- end }}
+  endpoints:
+  - port: metrics
+    path: /vars
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+{{- end }}

--- a/charts/lms/templates/orchestrator-deployment.yaml
+++ b/charts/lms/templates/orchestrator-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace : {{ .Release.namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.orchestrator.releaseName }}
   {{- with .Values.orchestrator.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -17,7 +16,6 @@ spec:
   selector:
     matchLabels:
       {{- include "molt-lms.selectorLabels" . | nindent 6 }}
-      release: {{ .Values.orchestrator.releaseName }}
   template:
     metadata:
     {{- with .Values.orchestrator.annotations }}
@@ -25,7 +23,6 @@ spec:
     {{- end }}
       labels:
         {{- include "molt-lms.selectorLabels" . | nindent 8 }}
-        release: {{ .Values.orchestrator.releaseName }}
       {{- with .Values.orchestrator.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
@@ -52,7 +49,7 @@ spec:
             - name: ORCH_SOURCE_DIALECT
               value: {{ .Values.orchestrator.sourceDialect }}
             - name: ORCH_TARGET_DIALECT
-              value: {{ .Values.orchestrator.targetDialect }}
+              value: "cockroach"
             - name: ORCH_ALLOW_ORIGIN
               value: {{ .Values.orchestrator.allowOrigin }}
           {{- with .Values.orchestrator.env }}

--- a/charts/lms/templates/orchestrator-deployment.yaml
+++ b/charts/lms/templates/orchestrator-deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "molt-lms.fullname" . }}-orchestrator
+  namespace : {{ .Release.namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.orchestrator.releaseName }}
+  {{- with .Values.orchestrator.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "molt-lms.selectorLabels" . | nindent 6 }}
+      release: {{ .Values.orchestrator.releaseName }}
+  template:
+    metadata:
+    {{- with .Values.orchestrator.annotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "molt-lms.selectorLabels" . | nindent 8 }}
+        release: {{ .Values.orchestrator.releaseName }}
+      {{- with .Values.orchestrator.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+      {{- with .Values.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "molt-lms.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: molt-lms-orchestrator
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: ORCH_K8S_LMS_PORT
+              value: {{ .Values.lms.service.port | quote }}
+            - name: ORCH_K8S_LMS_SERVICE_NAME
+              value: {{ include "molt-lms.fullname" . }}
+            - name: ORCH_K8S_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: ORCH_SOURCE_DIALECT
+              value: {{ .Values.orchestrator.sourceDialect }}
+            - name: ORCH_TARGET_DIALECT
+              value: {{ .Values.orchestrator.targetDialect }}
+            - name: ORCH_ALLOW_ORIGIN
+              value: {{ .Values.orchestrator.allowOrigin }}
+          {{- with .Values.orchestrator.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command: ["/bin/sh", "-c"]
+          args: [
+          "./molt-lms-orchestrator --k8s-running"
+          ]
+          ports:
+            - name: orchestrator
+              containerPort: {{ .Values.orchestrator.service.port }}
+            - name: orch-metrics
+              containerPort: {{ .Values.orchestrator.service.metricsPort }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: orch-metrics
+              scheme: HTTP
+          resources:
+            {{- toYaml .Values.orchestrator.resources | nindent 12 }}
+      {{- if or .Values.orchestrator.configSecretName .Values.orchestrator.sslVolumes .Values.orchestrator.sslVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.orchestrator.configSecretName }}
+            - mountPath: "/app/configs"
+              name: {{ .Values.orchestrator.configSecretName }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.orchestrator.sslVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        {{- if .Values.orchestrator.configSecretName }}
+        - name: {{ .Values.orchestrator.configSecretName }}
+          secret:
+            secretName: {{ .Values.orchestrator.configSecretName }}
+        {{- end }}
+        {{- with .Values.orchestrator.sslVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.orchestrator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lms/templates/orchestrator-service.yaml
+++ b/charts/lms/templates/orchestrator-service.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.orchestrator.releaseName }}
   {{- with .Values.orchestrator.service.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -25,7 +24,6 @@ spec:
       name: orch-metrics
   selector:
     {{- include "molt-lms.selectorLabels" . | nindent 4 }}
-    release: {{ .Values.orchestrator.releaseName }}
   {{- with .Values.orchestrator.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/lms/templates/orchestrator-service.yaml
+++ b/charts/lms/templates/orchestrator-service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "molt-lms.fullname" . }}-orchestrator
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.orchestrator.releaseName }}
+  {{- with .Values.orchestrator.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.orchestrator.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.orchestrator.service.type }}
+  ports:
+    - port: {{ .Values.orchestrator.service.port }}
+      name: orch
+    - port: {{ .Values.orchestrator.service.metricsPort }}
+      name: orch-metrics
+  selector:
+    {{- include "molt-lms.selectorLabels" . | nindent 4 }}
+    release: {{ .Values.orchestrator.releaseName }}
+  {{- with .Values.orchestrator.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/lms/templates/orchestrator-serviceMonitor.yaml
+++ b/charts/lms/templates/orchestrator-serviceMonitor.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace : {{ .Release.namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.orchestrator.releaseName }}
   {{- with .Values.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -21,7 +20,6 @@ spec:
   selector:
     matchLabels:
       {{- include "molt-lms.selectorLabels" . | nindent 6 }}
-      release: {{ .Values.orchestrator.releaseName }}
     {{- with .Values.orchestrator.service.labels }}
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/lms/templates/orchestrator-serviceMonitor.yaml
+++ b/charts/lms/templates/orchestrator-serviceMonitor.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "molt-lms.fullname" . }}-orchestrator
+  namespace : {{ .Release.namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.orchestrator.releaseName }}
+  {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "molt-lms.selectorLabels" . | nindent 6 }}
+      release: {{ .Values.orchestrator.releaseName }}
+    {{- with .Values.orchestrator.service.labels }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.orchestrator.service.labels }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  namespaceSelector:
+  {{- if .Values.serviceMonitor.namespaced }}
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- else }}
+    any: true
+  {{- end }}
+  endpoints:
+  - port: orch-metrics
+    path: /metrics
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+{{- end }}

--- a/charts/lms/templates/serviceaccount.yaml
+++ b/charts/lms/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "molt-lms.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lms/templates/serviceaccount.yaml
+++ b/charts/lms/templates/serviceaccount.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
-    release: {{ .Values.lms.releaseName }}
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/lms/values.yaml
+++ b/charts/lms/values.yaml
@@ -34,7 +34,6 @@ securityContext: {}
 
 lms:
   replicaCount: 3
-  releaseName: "molt-lms"
   sourceDialect: ""
   shadowMode: none
 
@@ -84,13 +83,11 @@ lms:
   nodeSelector: {}
 
 orchestrator:
-  releaseName: "molt-lms-orchestrator"
   sourceDialect: ""
-  targetDialect: 'cockroach'
   configSecretName: ""
   # allowOrigin specifies the pattern or exact host(s) that should be
   # allowed to make requests from a browser (CORS).
-  allowOrigin: "/.*localhost.*/"
+  allowOrigin: ""
 
   # Used for orchestrator ssl certs.
   # We recommend mounting to /app/certs. If set, make sure to set
@@ -137,4 +134,4 @@ serviceMonitor:
   labels: {}
   annotations: {}
   interval: 30s
-  namespaced: true
+  namespaced: false

--- a/charts/lms/values.yaml
+++ b/charts/lms/values.yaml
@@ -1,0 +1,140 @@
+# Overrides the chart name against the label "app.kubernetes.io/name: " placed on every resource this chart creates.
+nameOverride: ""
+
+# Override the resource names created by this chart which originally is generated using release and chart name.
+fullnameOverride: ""
+
+# Additional labels to apply to all Kubernetes resources created by this chart.
+labels: {}
+
+image:
+  repository: cockroachdb/molt-lms
+  pullPolicy: IfNotPresent
+  tag: 0.1.0
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+lms:
+  replicaCount: 3
+  releaseName: "molt-lms"
+  sourceDialect: ""
+  shadowMode: none
+
+  # Name of the secret containing the JSON format of 
+  # environment variables.
+  configSecretName: ""
+
+  # Used for mounting MySQL and/or LMS server side certs.
+  # We recommend mounting to /app/certs. If set, make sure to set
+  # the following env vars as appropriate. 
+  # LMS_SSL_CERT, LMS_SSL_KEY, LMS_SSL_CA 
+  # LMS_MYSQL_SSL_CA, LMS_MYSQL_SSL_KEY, LMS_SSL_MYSQL_CERT
+  # where the value is the path to the file such as '/app/certs/lms-cert.pem'.
+  # sslVolumes:
+  #   - name: mysqlca
+  #     secret:
+  #       secretName: mysqlca
+  # sslVolumeMounts:
+  #   - mountPath: "/app/certs"
+  #     name: mysqlca
+  #     readOnly: true
+  sslVolumes: {}
+  sslVolumeMounts: {}
+
+  env: []
+  labels: {}
+  annotations: {}
+
+  service:
+    type: ClusterIP
+    port: 9043
+    metricsPort: 9044
+    labels: {}
+    annotations: {}
+    
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  resources: {}
+  nodeSelector: {}
+
+orchestrator:
+  releaseName: "molt-lms-orchestrator"
+  sourceDialect: ""
+  targetDialect: 'cockroach'
+  configSecretName: ""
+  # allowOrigin specifies the pattern or exact host(s) that should be
+  # allowed to make requests from a browser (CORS).
+  allowOrigin: "/.*localhost.*/"
+
+  # Used for orchestrator ssl certs.
+  # We recommend mounting to /app/certs. If set, make sure to set
+  # the following env vars as appropriate. 
+  # ORCH_CA_TLS_CERT, ORCH_TLS_CERT, ORCH_TLS_KEY 
+  # where the value is the path to the file such as '/app/certs/orch-cert.pem'.
+  # sslVolumes:
+  #   - name: orch-cert
+  #     secret:
+  #       secretName: orch-cert
+  # sslVolumeMounts:
+  #   - mountPath: "/app/certs"
+  #     name: orch-cert
+  #     readOnly: true
+  sslVolumes: {}
+  sslVolumeMounts: {}
+
+  env: []
+  labels: {}
+  annotations: {}
+
+  service:
+    type: ClusterIP
+    port: 4200
+    metricsPort: 4201
+    labels: {}
+    annotations: {}
+  
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  resources: {}
+  nodeSelector: {}
+
+serviceMonitor:
+  enabled: false
+  labels: {}
+  annotations: {}
+  interval: 30s
+  namespaced: true


### PR DESCRIPTION
This commit adds the production helm chart for the LMS. It will deploy the LMS and Orchestrator by itself with full customization over how you want to configure it. There is an optional service monitor that can be installed if running with the prometheus operator.