### PR TITLE
LMS: Fix helm chart service discovery

### DIFF
--- a/charts/lms/templates/lms-deployment.yaml
+++ b/charts/lms/templates/lms-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
   {{- with .Values.lms.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -16,6 +17,7 @@ spec:
   selector:
     matchLabels:
       {{- include "molt-lms.selectorLabels" . | nindent 6 }}
+      release: {{ .Values.lms.releaseName }}
   template:
     metadata:
     {{- with .Values.lms.annotations }}
@@ -23,6 +25,7 @@ spec:
     {{- end }}
       labels:
         {{- include "molt-lms.selectorLabels" . | nindent 8 }}
+        release: {{ .Values.lms.releaseName }}
       {{- with .Values.lms.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}

--- a/charts/lms/templates/lms-role.yaml
+++ b/charts/lms/templates/lms-role.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,6 +25,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/lms/templates/lms-service.yaml
+++ b/charts/lms/templates/lms-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace : {{ .Release.namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
   {{- with .Values.lms.service.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -26,6 +27,7 @@ spec:
       protocol: TCP
   selector:
     {{- include "molt-lms.selectorLabels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
   {{- with .Values.lms.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/lms/templates/lms-serviceMonitor.yaml
+++ b/charts/lms/templates/lms-serviceMonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace : {{ .Release.namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
   {{- with .Values.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -20,6 +21,7 @@ spec:
   selector:
     matchLabels:
       {{- include "molt-lms.selectorLabels" . | nindent 6 }}
+      release: {{ .Values.lms.releaseName }}
     {{- with .Values.lms.service.labels }}
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/lms/templates/orchestrator-deployment.yaml
+++ b/charts/lms/templates/orchestrator-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace : {{ .Release.namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.orchestrator.releaseName }}
   {{- with .Values.orchestrator.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -16,6 +17,7 @@ spec:
   selector:
     matchLabels:
       {{- include "molt-lms.selectorLabels" . | nindent 6 }}
+      release: {{ .Values.orchestrator.releaseName }}
   template:
     metadata:
     {{- with .Values.orchestrator.annotations }}
@@ -23,6 +25,7 @@ spec:
     {{- end }}
       labels:
         {{- include "molt-lms.selectorLabels" . | nindent 8 }}
+        release: {{ .Values.orchestrator.releaseName }}
       {{- with .Values.orchestrator.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}

--- a/charts/lms/templates/orchestrator-service.yaml
+++ b/charts/lms/templates/orchestrator-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.orchestrator.releaseName }}
   {{- with .Values.orchestrator.service.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,6 +25,7 @@ spec:
       name: orch-metrics
   selector:
     {{- include "molt-lms.selectorLabels" . | nindent 4 }}
+    release: {{ .Values.orchestrator.releaseName }}
   {{- with .Values.orchestrator.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/lms/templates/orchestrator-serviceMonitor.yaml
+++ b/charts/lms/templates/orchestrator-serviceMonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace : {{ .Release.namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.orchestrator.releaseName }}
   {{- with .Values.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -20,6 +21,7 @@ spec:
   selector:
     matchLabels:
       {{- include "molt-lms.selectorLabels" . | nindent 6 }}
+      release: {{ .Values.orchestrator.releaseName }}
     {{- with .Values.orchestrator.service.labels }}
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/lms/templates/serviceaccount.yaml
+++ b/charts/lms/templates/serviceaccount.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "molt-lms.labels" . | nindent 4 }}
+    release: {{ .Values.lms.releaseName }}
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/lms/values.yaml
+++ b/charts/lms/values.yaml
@@ -34,6 +34,7 @@ securityContext: {}
 
 lms:
   replicaCount: 3
+  releaseName: "molt-lms"
   sourceDialect: ""
   shadowMode: none
   logLevel: info
@@ -83,6 +84,7 @@ lms:
   nodeSelector: {}
 
 orchestrator:
+  releaseName: "molt-lms-orchestrator"
   sourceDialect: ""
   configSecretName: ""
   # allowOrigin specifies the pattern or exact host(s) that should be


### PR DESCRIPTION
This reverts commit 69d17d6939ae1e6309d0c021d97b5a22583cc29a by readding the release label. The services were not looking up the correct pods due to conflicting selector blocks.