### PR TITLE
fetch: added in the config flag/option for configuring a number of rows to flush after

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -113,6 +113,12 @@ func Command() *cobra.Command {
 		"if set, size (in bytes) before the data source is flushed",
 	)
 	cmd.PersistentFlags().IntVar(
+		&cfg.FlushRows,
+		"flush-rows",
+		0,
+		"if set, number of rows before the data source is flushed",
+	)
+	cmd.PersistentFlags().IntVar(
 		&cfg.Concurrency,
 		"concurrency",
 		4,

--- a/fetch/export_table.go
+++ b/fetch/export_table.go
@@ -28,6 +28,7 @@ func exportTable(
 	datasource datablobstorage.Store,
 	table dbtable.VerifiedTable,
 	flushSize int,
+	flushRows int,
 ) (exportResult, error) {
 	ret := exportResult{
 		StartTime: time.Now(),
@@ -59,7 +60,7 @@ func exportTable(
 	itNum := 0
 	// Errors must be buffered, as pipe can exit without taking the error channel.
 	writerErrCh := make(chan error, 1)
-	pipe := newCSVPipe(sqlRead, logger, flushSize, func() io.WriteCloser {
+	pipe := newCSVPipe(sqlRead, logger, flushSize, flushRows, func() io.WriteCloser {
 		resourceWG.Wait()
 		forwardRead, forwardWrite := io.Pipe()
 		resourceWG.Add(1)

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -19,6 +19,7 @@ import (
 
 type Config struct {
 	FlushSize   int
+	FlushRows   int
 	Cleanup     bool
 	Live        bool
 	Truncate    bool
@@ -57,6 +58,7 @@ func Fetch(
 
 	logger.Debug().
 		Int("flush_size", cfg.FlushSize).
+		Int("flush_num_rows", cfg.FlushRows).
 		Str("store", fmt.Sprintf("%T", blobStore)).
 		Msg("initial config")
 
@@ -176,7 +178,7 @@ func fetchTable(
 
 	logger.Info().Msgf("data extraction phase starting")
 
-	e, err := exportTable(ctx, logger, sqlSrc, blobStore, table.VerifiedTable, cfg.FlushSize)
+	e, err := exportTable(ctx, logger, sqlSrc, blobStore, table.VerifiedTable, cfg.FlushSize, cfg.FlushRows)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added in an optimization parameter so that users can control the number of rows after for the exportTable job to flush.

Resolves: #14
Release Note: None