### PR TITLE
Fix CDN invalidation command

### DIFF
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -52,6 +52,6 @@ jobs:
     - name: Invalidate CDN cache
       if: ${{ github.event_name == 'release' }}
       run: |
-        gcloud compute url-maps invalidate-cdn-cache molt-lms-release-artifacts-prod --path "/lms/charts/*" --async
+        gcloud compute url-maps invalidate-cdn-cache molt-lms-release-artifacts-prod-default --path "/lms/charts/*" --async
 
 


### PR DESCRIPTION
The command should be using the URL-mao name instead of the CDN name.