### PR TITLE
fetch: added in progress indicator for the import table jobs

### DIFF
--- a/fetch/datablobstorage/local.go
+++ b/fetch/datablobstorage/local.go
@@ -53,7 +53,9 @@ func NewLocalStore(
 				Str("listen-addr", listenAddr).
 				Str("crdb-access-addr", crdbAccessAddr).
 				Msgf("starting file server")
-			if err := server.ListenAndServe(); err != nil {
+			if err := server.ListenAndServe(); err != nil && err == http.ErrServerClosed {
+				logger.Info().Msgf("http server intentionally shut down")
+			} else if err != nil {
 				logger.Err(err).Msgf("error starting file server")
 			}
 		}()

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -219,6 +219,18 @@ func fetchTable(
 				Msgf("starting data import on target")
 
 			if !cfg.Live {
+				go func() {
+					err := reportImportTableProgress(ctx,
+						targetConn,
+						logger,
+						table.VerifiedTable,
+						time.Now(),
+						false /*testing*/)
+					if err != nil {
+						logger.Err(err).Msg("failed to report import table progress")
+					}
+				}()
+
 				r, err := importTable(ctx, cfg, targetConn, logger, table.VerifiedTable, e.Resources)
 				if err != nil {
 					return err

--- a/fetch/import_table.go
+++ b/fetch/import_table.go
@@ -2,6 +2,10 @@ package fetch
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
@@ -12,12 +16,105 @@ import (
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
 	"github.com/cockroachdb/molt/fetch/internal/dataquery"
 	"github.com/cockroachdb/molt/retry"
+	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 )
 
 type importResult struct {
 	StartTime time.Time
 	EndTime   time.Time
+}
+
+type importProgress struct {
+	Description       string
+	Started           time.Time
+	FractionCompleted float64 `db:"fraction_completed"`
+}
+
+const (
+	pattern     = `%`
+	replacement = `\%`
+)
+
+var re = regexp.MustCompile(pattern)
+
+func getShowJobsQuery(table dbtable.VerifiedTable, curTime string) string {
+	schema := strings.Trim(re.ReplaceAllLiteralString(table.Schema.String(), replacement), `"`)
+	tableName := strings.Trim(re.ReplaceAllLiteralString(table.Table.String(), replacement), `"`)
+	return fmt.Sprintf(`WITH x as (SHOW JOBS)
+SELECT description, started, fraction_completed
+FROM x
+WHERE job_type='IMPORT'
+    AND description LIKE '%%%s.%s(%%'
+    AND started > '%s'
+ORDER BY created DESC`,
+		schema, tableName, curTime)
+}
+
+func reportImportTableProgress(
+	ctx context.Context,
+	baseConn dbconn.Conn,
+	logger zerolog.Logger,
+	table dbtable.VerifiedTable,
+	curTime time.Time,
+	testing bool,
+) error {
+	curTimeUTC := curTime.UTC().Format("2006-01-02T15:04:05")
+	r, err := retry.NewRetry(retry.Settings{
+		InitialBackoff: 10 * time.Second,
+		Multiplier:     1,
+		MaxRetries:     math.MaxInt64,
+	})
+	if err != nil {
+		return err
+	}
+
+	pgConn, ok := baseConn.(*dbconn.PGConn)
+	if !ok {
+		return errors.Newf("expected pgx conn, got %T", baseConn)
+	}
+
+	conn, err := pgx.ConnectConfig(ctx, pgConn.Config())
+	if err != nil {
+		return err
+	}
+	defer conn.Close(ctx)
+
+	prevVal := 0.0
+
+	if err := r.Do(func() error {
+		query := getShowJobsQuery(table, curTimeUTC)
+		rows, err := conn.Query(ctx, query)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		p, err := pgx.CollectRows(rows, pgx.RowToStructByName[importProgress])
+		if err != nil {
+			return err
+		} else if len(p) == 0 {
+			return errors.New("retrying because no rows found")
+		} else if p[0].FractionCompleted != 1 {
+			frac := p[0].FractionCompleted
+			if frac != 0.0 && prevVal != frac {
+				logger.Info().Str("completion", fmt.Sprintf("%.2f%%", frac*100)).Msgf("progress")
+			}
+
+			prevVal = p[0].FractionCompleted
+			return errors.New("retrying because job not finished yet")
+		}
+
+		if testing {
+			logger.Info().Msgf("%.2f%% completed (%s.%s)", p[0].FractionCompleted*100, table.Schema.String(), table.Table.String())
+		}
+
+		return nil
+	}, func(err error) {}); err != nil {
+		return err
+	}
+
+	return err
 }
 
 func importTable(

--- a/fetch/import_table_test.go
+++ b/fetch/import_table_test.go
@@ -1,0 +1,179 @@
+package fetch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+	"github.com/cockroachdb/molt/dbconn"
+	"github.com/cockroachdb/molt/dbtable"
+	"github.com/cockroachdb/molt/retry"
+	"github.com/cockroachdb/molt/testutils"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+const listenAddr = "0.0.0.0:4041"
+const filePath = "./testdata/csv/"
+const createTableStmt = "CREATE TABLE IF NOT EXISTS teams (id INT PRIMARY KEY, name STRING, role STRING)"
+const dropTableStmt = "DROP TABLE teams"
+
+func getTestFileServer() *http.Server {
+	return &http.Server{
+		Addr:    listenAddr,
+		Handler: http.FileServer(http.Dir(filePath)),
+	}
+}
+
+func verifyValidServerResponse(t *testing.T, URL string) error {
+	r, err := retry.NewRetry(retry.Settings{
+		InitialBackoff: 1 * time.Second,
+		Multiplier:     1,
+		MaxRetries:     5,
+	})
+	require.NoError(t, err)
+
+	if err := r.Do(func() error {
+		response, err := http.Get(URL)
+		if err != nil {
+			return err
+		}
+
+		responseData, err := io.ReadAll(response.Body)
+		if err != nil {
+			return err
+		}
+
+		t.Log(string(responseData))
+		return err
+	}, func(err error) {
+		t.Log(err)
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestReportImportTableProgress(t *testing.T) {
+	t.Run("successfully reports import progress", func(t *testing.T) {
+		curTime := time.Now()
+		ctx := context.Background()
+		srv := getTestFileServer()
+		go func() {
+			t.Logf("serving HTTP at %s", listenAddr)
+			if err := srv.ListenAndServe(); err != nil {
+				t.Logf("error starting server: %s", err)
+			}
+		}()
+		defer func() {
+			err := srv.Shutdown(ctx)
+			require.NoError(t, err)
+		}()
+
+		path := fmt.Sprintf("http://%s/import_basic_000.csv", listenAddr)
+		err := verifyValidServerResponse(t, path)
+		require.NoError(t, err)
+
+		dbName := "fetch_test_report_import"
+		conn, err := dbconn.TestOnlyCleanDatabase(ctx, "target", testutils.CRDBConnStr(), dbName)
+		require.NoError(t, err)
+
+		pgConn, ok := conn.(*dbconn.PGConn)
+		require.Equal(t, true, ok)
+
+		_, err = pgConn.Exec(ctx, createTableStmt)
+		defer func() {
+			_, err := pgConn.Exec(ctx, dropTableStmt)
+			require.NoError(t, err)
+		}()
+		require.NoError(t, err)
+
+		importStmt := fmt.Sprintf(`IMPORT INTO teams(id, name, role) CSV DATA ('http://%s/import_basic_000.csv')`, listenAddr)
+		_, err = pgConn.Exec(ctx, importStmt)
+		require.NoError(t, err)
+		var b bytes.Buffer
+		logger := zerolog.New(&b)
+
+		err = reportImportTableProgress(ctx, conn, logger, dbtable.VerifiedTable{
+			Name: dbtable.Name{
+				Schema: tree.Name("public"),
+				Table:  tree.Name("teams"),
+			},
+		}, curTime, true /*testing*/)
+		require.NoError(t, err)
+		require.Equal(t, `{"level":"info","message":"100.00% completed (public.teams)"}
+`, b.String())
+	})
+
+	t.Run("wrong connection type passed in", func(t *testing.T) {
+		curTime := time.Now()
+		ctx := context.Background()
+		dbName := "fetch_test_report_import"
+		conn, err := dbconn.TestOnlyCleanDatabase(ctx, "target", testutils.MySQLConnStr(), dbName)
+		require.NoError(t, err)
+
+		logger := zerolog.New(zerolog.NewConsoleWriter())
+		err = reportImportTableProgress(ctx, conn, logger, dbtable.VerifiedTable{
+			Name: dbtable.Name{
+				Schema: tree.Name("public"),
+				Table:  tree.Name("teams"),
+			},
+		}, curTime, true /*testing*/)
+		require.EqualError(t, err, "expected pgx conn, got *dbconn.MySQLConn")
+	})
+}
+
+func TestGetShowJobsQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		table    dbtable.VerifiedTable
+		curTime  string
+		expected string
+	}{
+		{
+			name: "normal schema and table",
+			table: dbtable.VerifiedTable{
+				Name: dbtable.Name{
+					Schema: tree.Name("public"),
+					Table:  tree.Name("test1"),
+				},
+			},
+			curTime: "2006-01-02T15:04:05",
+			expected: `WITH x as (SHOW JOBS)
+SELECT description, started, fraction_completed
+FROM x
+WHERE job_type='IMPORT'
+    AND description LIKE '%public.test1(%'
+    AND started > '2006-01-02T15:04:05'
+ORDER BY created DESC`,
+		},
+		{
+			name: "escaped percent symbol",
+			table: dbtable.VerifiedTable{
+				Name: dbtable.Name{
+					Schema: tree.Name("public"),
+					Table:  tree.Name("test%1"),
+				},
+			},
+			curTime: "2006-01-02T15:04:05",
+			expected: `WITH x as (SHOW JOBS)
+SELECT description, started, fraction_completed
+FROM x
+WHERE job_type='IMPORT'
+    AND description LIKE '%public.test\%1(%'
+    AND started > '2006-01-02T15:04:05'
+ORDER BY created DESC`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			query := getShowJobsQuery(tc.table, tc.curTime)
+			require.Equal(t, tc.expected, query)
+		})
+	}
+}

--- a/fetch/testdata/csv/import_basic_000.csv
+++ b/fetch/testdata/csv/import_basic_000.csv
@@ -1,0 +1,5 @@
+1,ryan,dev
+2,jeremy,dev
+3,jane,dev
+4,oliver,tl
+5,adam,manager


### PR DESCRIPTION
Added in a Go routine that repeatedly queries the database for the IMPORT job and reports progress to the STDOUT.

Release Note: None

Action items:
- [x] Don't print 0 if that's the percentage
- [x] Don't print the same number multiple times
- [x] Ask #sql to know how the fraction_completed is calculated