### PR TITLE
MOLT: Bump to build with Go 1.21

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  GO_VERSION: "1.21"
+
 jobs:
   test:
     name: Test
@@ -29,6 +32,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: CACHE_KEY
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Test
         run: |
@@ -64,7 +68,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -88,6 +92,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: CACHE_KEY
+          go-version: ${{ env.GO_VERSION }}
 
       - name: crlfmt returns no deltas
         if: ${{ always() }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  GO_VERSION: "1.21"
+
 jobs:
   release-linux:
     runs-on: ubuntu-latest
@@ -12,6 +15,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Setup Golang
       uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.GO_VERSION }}
     - name: Create release directory
       run: mkdir -p artifacts
     - name: Build Linux AMD64
@@ -28,6 +33,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Golang
         uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Create release directory
         run: mkdir -p artifacts
       - name: Build Linux AMD64
@@ -44,6 +51,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Golang
         uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Create release directory
         run: mkdir -p artifacts
       - name: Build OSX

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/molt
 
-go 1.19
+go 1.21
 
 require (
 	cloud.google.com/go/storage v1.31.0


### PR DESCRIPTION
This commit bumps the molt repo to build the binaries with golang version 1.21.