### PR TITLE
MOLT: Add docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3"
+
+services:
+  mysql:
+    image: mysql:latest
+    restart: always
+    working_dir: /mysql
+    environment:
+      MYSQL_DATABASE: "defaultdb"
+      MYSQL_USER: "admin"
+      MYSQL_PASSWORD: "admin"
+      MYSQL_ROOT_PASSWORD: "password"
+    command:
+      - --enforce-gtid-consistency=ON
+      - --gtid-mode=ON
+    volumes:
+      - ./mysql-init:/docker-entrypoint-initdb.d
+    ports:
+      - "3306:3306"
+
+  postgres:
+    image: postgres:latest
+    restart: always
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - '5432:5432'
+    volumes: 
+      - ./pg-init:/docker-entrypoint-initdb.d

--- a/docker/mysql-init/mysql-init.sql
+++ b/docker/mysql-init/mysql-init.sql
@@ -1,0 +1,15 @@
+CREATE DATABASE molt;
+use molt;
+CREATE TABLE employees (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    unique_id BINARY(16),
+    name VARCHAR(50),
+    created_at DATETIME,
+    updated_at DATE,
+    is_hired TINYINT(1),
+    salary DECIMAL(8, 2),
+    bonus FLOAT
+);
+INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, salary, bonus)
+VALUES (UNHEX(REPLACE('550e8400-e29b-41d4-a716-446655440000', '-', '')), 'John Doe', '2023-11-03 09:00:00', '2023-11-03', 1, 5000.00, 100.25);
+

--- a/docker/pg-init/pg-init.sql
+++ b/docker/pg-init/pg-init.sql
@@ -1,0 +1,24 @@
+CREATE DATABASE molt;
+\c molt;
+
+CREATE TABLE employees (
+    id serial PRIMARY KEY,
+    unique_id UUID,
+    name VARCHAR(50),
+    created_at TIMESTAMPTZ,
+    updated_at DATE,
+    is_hired BOOLEAN,
+    salary NUMERIC(8, 2),
+    bonus REAL
+);
+
+INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, salary, bonus)
+VALUES (
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    'John Doe',
+    '2023-11-03 09:00:00'::timestamp,
+    '2023-11-03'::date,
+    true,
+    5000.00,
+    100.25
+);


### PR DESCRIPTION
This commit adds a basic docker compose for testing purposes. Right now it only spins up mysql with the database and a single row