### PR TITLE
fetch: fixed direct-copy functionality and disallow compression for COPY modes

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -40,14 +40,15 @@ func Command() *cobra.Command {
 			}
 			cmdutil.RunMetricsServer(logger)
 
-			if cfg.Live {
+			isCopyMode := cfg.Live || directCRDBCopy
+			if isCopyMode {
 				if cfg.Compression == compression.GZIP {
-					return errors.New("cannot run live mode with compression")
+					return errors.New("cannot run copy mode with compression")
 				} else if cfg.Compression <= compression.Default {
 					logger.Info().Msgf("default compression to none")
 					cfg.Compression = compression.None
 				}
-			} else {
+			} else if !isCopyMode && cfg.Compression == compression.Default {
 				logger.Info().Msgf("default compression to gzip")
 				cfg.Compression = compression.GZIP
 			}


### PR DESCRIPTION
Previously, compression was applied for a default for both the non-live mode and direct copy without the live flag. This made the writer for copy compressed by default, leading to an issue when copying. This change makes it so that we don't allow compression while copying and updating the default logic so that we can properly pass in compression opts.

Resolves: #60 
Release Note: None

**Test Run**
```
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . fetch \
  --source 'postgres://postgres:migrations@molt-test-pg.cpa6lrp2ahsc.us-east-1.rds.amazonaws.com:5432/sourcedb' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' \
  --table-filter 'employees' \
  --s3-bucket molt-test --compression default
<nil> INF default compression to gzip
<nil> INF checking database details
<nil> INF found matching table source_table=public.employees target_table=public.employees
<nil> INF verifying common tables
<nil> INF establishing snapshot
<nil> INF starting fetch cdc_cursor=3/D4000088 num_tables=1
<nil> INF data extraction phase starting table=public.employees
<nil> INF row import status num_rows=100000 table=public.employees
<nil> INF row import status num_rows=200000 table=public.employees
<nil> INF data extraction from source complete export_duration=3495.847292 num_rows=200001 table=public.employees
<nil> INF starting data import on target table=public.employees
<nil> INF data import on target for table complete cdc_cursor=3/D4000088 import_duration=3549.000042 net_duration=7047.891166 table=public.employees
<nil> INF fetch complete cdc_cursor=3/D4000088 num_tables=1 tables=["public.employees"]
```