### PR TITLE
molt: made the command flags and descriptions consistent with other migrations tooling

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -28,9 +28,9 @@ func Command() *cobra.Command {
 		cfg                     fetch.Config
 	)
 	cmd := &cobra.Command{
-		Use:  "fetch",
-		Long: `Fetches data from source to directly import into target.`,
-
+		Use:   "fetch",
+		Short: "Moves data from source to target.",
+		Long:  `Imports data from source directly into target tables.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
@@ -108,103 +108,103 @@ func Command() *cobra.Command {
 		&directCRDBCopy,
 		"direct-copy",
 		false,
-		"whether to use direct copy mode",
+		"Enables direct copy mode, which copies data directly from source to target without using an intermediate store.",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&cfg.Cleanup,
 		"cleanup",
 		false,
-		"whether any file resources created should be deleted",
+		"Whether any created resources should be deleted.",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&cfg.Live,
 		"live",
 		false,
-		"whether the table must be queriable during load import",
+		"Whether the table must be queryable during load import.",
 	)
 	cmd.PersistentFlags().IntVar(
 		&cfg.FlushSize,
 		"flush-size",
 		0,
-		"if set, size (in bytes) before the data source is flushed",
+		"If set, size (in bytes) before the source data is flushed to intermediate files.",
 	)
 	cmd.PersistentFlags().IntVar(
 		&cfg.FlushRows,
 		"flush-rows",
 		0,
-		"if set, number of rows before the data source is flushed",
+		"If set, number of rows before the source data is flushed to intermediate files.",
 	)
 	cmd.PersistentFlags().IntVar(
 		&cfg.Concurrency,
 		"concurrency",
 		4,
-		"number of tables to move data with at a time",
+		"Number of tables to move at a time.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&s3Bucket,
 		"s3-bucket",
 		"",
-		"s3 bucket",
+		"Name of the S3 bucket.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&gcpBucket,
 		"gcp-bucket",
 		"",
-		"gcp bucket",
+		"Name of the GCP bucket.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&bucketPath,
 		"bucket-path",
 		"",
-		"path within the bucket to write intermediate files (i.e. test-migrations/v1 with no ending slash)",
+		"Path within the bucket where intermediate files are written (e.g., bucket-name/folder-name).",
 	)
 	cmd.PersistentFlags().StringVar(
 		&localPath,
 		"local-path",
 		"",
-		"path to upload files to locally",
+		"Path to upload files to locally.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&localPathListenAddr,
 		"local-path-listen-addr",
 		"",
-		"local address to listen to for traffic",
+		"Address of a local store server to listen to for traffic.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&localPathCRDBAccessAddr,
 		"local-path-crdb-access-addr",
 		"",
-		"address CockroachDB can access to connect to the --local-path-listen-addr",
+		"Address of data that CockroachDB can access to import from a local store (defaults to local-path-listen-addr).",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&cfg.Truncate,
 		"truncate",
 		false,
-		"whether to truncate the table being imported to",
+		"Whether to truncate the target tables before source data is imported.",
 	)
 	cmd.PersistentFlags().IntVar(
 		&cfg.ExportSettings.RowBatchSize,
 		"row-batch-size",
 		100_000,
-		"how many rows to select at a time for the database",
+		"Number of rows to select at a time for export from the source database.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&cfg.ExportSettings.PG.SlotName,
 		"pg-logical-replication-slot-name",
 		"",
-		"if set, the name of a replication slot that should be created before taking a snapshot of data",
+		"If set, the name of a replication slot that will be created before taking a snapshot of data.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&cfg.ExportSettings.PG.Plugin,
 		"pg-logical-replication-slot-plugin",
 		"pgoutput",
-		"if set, the output plugin used for logical replication under pg-logical-replication-slot-name",
+		"If set, the output plugin used for logical replication under pg-logical-replication-slot-name.",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&cfg.ExportSettings.PG.DropIfExists,
 		"pg-logical-replication-slot-drop-if-exists",
 		false,
-		"if set, drops the replication slot if it exists",
+		"If set, drops the replication slot if it exists.",
 	)
 	cmd.PersistentFlags().Var(
 		enumflag.New(
@@ -214,7 +214,7 @@ func Command() *cobra.Command {
 			enumflag.EnumCaseInsensitive,
 		),
 		"compression",
-		"compression to use (default/gzip/none)",
+		"Compression type (default/gzip/none) to use (IMPORT INTO mode only).",
 	)
 	cmdutil.RegisterDBConnFlags(cmd)
 	cmdutil.RegisterLoggerFlags(cmd)

--- a/cmd/internal/cmdutil/dbconn.go
+++ b/cmd/internal/cmdutil/dbconn.go
@@ -14,13 +14,13 @@ func RegisterDBConnFlags(cmd *cobra.Command) {
 		&DBConnConfig.Source,
 		"source",
 		"",
-		"URL of the source database",
+		"Connection string of the source database.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&DBConnConfig.Target,
 		"target",
 		"",
-		"URL of the target database",
+		"Connection string of the target database.",
 	)
 
 	for _, required := range []string{"source", "target"} {

--- a/cmd/internal/cmdutil/logger.go
+++ b/cmd/internal/cmdutil/logger.go
@@ -18,7 +18,7 @@ func RegisterLoggerFlags(cmd *cobra.Command) {
 		&loggerConfigInst.level,
 		"logging",
 		loggerConfigInst.level,
-		"what level to log at - maps to zerolog.Level",
+		"Level to log at (maps to zerolog.Level).",
 	)
 }
 

--- a/cmd/internal/cmdutil/name_filter.go
+++ b/cmd/internal/cmdutil/name_filter.go
@@ -12,13 +12,13 @@ func RegisterNameFilterFlags(cmd *cobra.Command) {
 		&tableFilter.TableFilter,
 		"table-filter",
 		tableFilter.TableFilter,
-		"POSIX regexp filter for tables to action on",
+		"POSIX regexp filter for tables to action on.",
 	)
 	cmd.PersistentFlags().StringVar(
 		&tableFilter.SchemaFilter,
 		"schema-filter",
 		tableFilter.SchemaFilter,
-		"POSIX regexp filter for schemas to action on",
+		"POSIX regexp filter for schemas to action on.",
 	)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,10 +9,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const rootCmdUse = "molt"
+
 var rootCmd = &cobra.Command{
 	Use:   "molt",
 	Short: "Onboarding assistance for migrating to CockroachDB",
 	Long:  `MOLT (Migrate Off Legacy Things) provides tooling which assists migrating off other database providers to CockroachDB.`,
+}
+
+func walk(c *cobra.Command, f func(*cobra.Command)) {
+	f(c)
+	for _, c := range c.Commands() {
+		walk(c, f)
+	}
 }
 
 func Execute() {
@@ -25,4 +34,18 @@ func Execute() {
 func init() {
 	rootCmd.AddCommand(verify.Command())
 	rootCmd.AddCommand(fetch.Command())
+
+	// Hide completion options, because irrelevant.
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+
+	// Overrides the default help text and descriptions.
+	walk(rootCmd, func(c *cobra.Command) {
+		c.Flags().BoolP("help", "h", false, fmt.Sprintf("Help for %s command.", c.Name()))
+	})
+	rootCmd.InitDefaultHelpCmd()
+	walk(rootCmd, func(c *cobra.Command) {
+		if c.Name() == "help" {
+			c.Short = fmt.Sprintf("Help command for %s.", rootCmdUse)
+		}
+	})
 }

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -95,97 +95,97 @@ func Command() *cobra.Command {
 		&verifyConcurrency,
 		"concurrency",
 		0,
-		"number of tables to process at a time (defaults to number of CPUs)",
+		"Number of tables to process at a time (defaults to number of CPUs).",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyTableSplits,
 		"table-splits",
 		1,
-		"number of shards to break down each table into whilst doing row-based verification",
+		"Number of shards to break down each table into while doing row-based verification.",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyRowBatchSize,
 		"row-batch-size",
 		20000,
-		"number of rows to get from a table at a time",
+		"Number of source/target rows to scan at a time.",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyLimitRowsPerSecond,
 		"rows-per-second",
 		0,
-		"if set, maximum number of rows to read per second during scanning per shard",
+		"If set, maximum number of rows to read per second on each shard.",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&verifyFixup,
 		"fixup",
 		false,
-		"whether to fix up any rows",
+		"Whether to fix up inconsistencies found during row verification.",
 	)
 	cmd.PersistentFlags().DurationVar(
 		&verifyContinuousPause,
 		"continuous-pause-between-runs",
 		0,
-		"time to pause between continuous runs",
+		"Amount of time to pause between continuous runs (e.g. 1h, 2m).",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&verifyContinuous,
 		"continuous",
 		false,
-		"whether verification should continuously run on each shard",
+		"Whether verification should continuously run on each shard.",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&verifyLive,
 		"live",
 		false,
-		"enables live mode, which attempts to account for rows that can change in value by retrying them before marking them as an inconsistency",
+		"Enable live mode, which attempts to account for rows that can change in value by retrying them before marking them as inconsistent.",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&verifyRows,
 		"rows",
 		true,
-		"whether rows should be verified (otherwise, performs a more basic schema check)",
+		"If true, verify both the schema (columns, types) and row data. If false, verify only the schema.",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyLiveVerificationSettings.RunsPerSecond,
 		"live-runs-per-second",
 		verifyLiveVerificationSettings.RunsPerSecond,
-		"if set, sets a maximum number of attempts to reverify per second",
+		"Maximum number of retry attempts per second (live mode only).",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyLiveVerificationSettings.MaxBatchSize,
 		"live-max-batch-size",
 		verifyLiveVerificationSettings.MaxBatchSize,
-		"maximum number of rows to retry at a time in live verification mode",
+		"Maximum number of rows to retry at a time (live mode only).",
 	)
 	cmd.PersistentFlags().DurationVar(
 		&verifyLiveVerificationSettings.FlushInterval,
 		"live-flush-interval",
 		verifyLiveVerificationSettings.FlushInterval,
-		"maximum amount of time to wait before rows can start being retried",
+		"Maximum amount of time to wait before retrying rows (live mode only).",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyLiveVerificationSettings.RetrySettings.MaxRetries,
 		"live-retries-max-iterations",
 		verifyLiveVerificationSettings.RetrySettings.MaxRetries,
-		"maximum number of retries live reverification should run before marking rows as inconsistent",
+		"Maximum number of retries before marking rows as inconsistent (live mode only).",
 	)
 	cmd.PersistentFlags().DurationVar(
 		&verifyLiveVerificationSettings.RetrySettings.MaxBackoff,
 		"live-retry-max-backoff",
 		verifyLiveVerificationSettings.RetrySettings.MaxBackoff,
-		"maximum amount of time live reverification should take before retrying",
+		"Maximum amount of time a retry attempt should take before retrying again (live mode only).",
 	)
 	cmd.PersistentFlags().DurationVar(
 		&verifyLiveVerificationSettings.RetrySettings.InitialBackoff,
 		"live-retry-initial-backoff",
 		verifyLiveVerificationSettings.RetrySettings.InitialBackoff,
-		"amount of time live verification should initially backoff for before retrying",
+		"Amount of time live verification should initially backoff for before retrying.",
 	)
 	cmd.PersistentFlags().IntVar(
 		&verifyLiveVerificationSettings.RetrySettings.Multiplier,
 		"live-retry-multiplier",
 		verifyLiveVerificationSettings.RetrySettings.Multiplier,
-		"multiplier applied to retry after each unsuccessful live reverification run",
+		"Multiplier to apply to backoff duration after each failed row verification (live mode only).",
 	)
 	for _, hidden := range []string{"fixup", "table-splits"} {
 		if err := cmd.PersistentFlags().MarkHidden(hidden); err != nil {


### PR DESCRIPTION


Made the command descriptions and flags have consistent formatting. Prioritizing full sentences and better clarity about what each flag does for both fetch and verify. Also made the help command and autocomplete hooks so that it has behavior we expect. Removed the autocomplete command because that is extraneous.

Resolves: #59
Release Note: None