### PR TITLE
molt: unify the release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,24 @@
 name: release
 
 on:
+  push:
+    branches:
+      - main
   release:
     types: [published]
+  workflow_dispatch: # Allow manual runs to manually define releases
+  
 
 env:
   GO_VERSION: "1.21"
 
 jobs:
-  release-linux:
+  release-cli:
+    environment: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -17,50 +26,60 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: Create release directory
-      run: mkdir -p artifacts
-    - name: Build Linux AMD64
-      run: GOOS=linux GOARCH=amd64 go build -v -o artifacts/molt.linux.amd64 .
-    - name: Publish to release
-      uses: AButler/upload-release-assets@v2.0
+    - name: Clean and create release directory
+      run: rm -rf ./artifacts && mkdir -p artifacts
+    - name: Extract the ref or tag from the GITHUB_REF
+      id: extract
+      run: | 
+          echo "Ref: ${GITHUB_REF_NAME#v}"
+          echo "tag=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+    - name: Build for all OS and architecture combinations using tag # When triggered by a release.
+      if: ${{ github.event_name == 'release' }}
+      run: |
+        VERSION=${GITHUB_REF_NAME#v}
+        make build_molt_cli version="$VERSION"
+    - name: Build for all OS and architecture combinations using sha # When kicked off without a release.
+      if: ${{ github.event_name != 'release' }}
+      run: make build_molt_cli version="g${{ github.sha }}"
+    - name: 'auth'
+      uses: 'google-github-actions/auth@v1'
       with:
-        files: 'artifacts/*'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-  release-windows:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Golang
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Create release directory
-        run: mkdir -p artifacts
-      - name: Build Linux AMD64
-        run: GOOS=windows GOARCH=amd64 go build -v -o artifacts/molt.amd64.exe .
-      - name: Publish to release
-        uses: AButler/upload-release-assets@v2.0
-        with:
-          files: 'artifacts/*'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-  release-osx:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Golang
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Create release directory
-        run: mkdir -p artifacts
-      - name: Build OSX
-        run: GOOS=darwin GOARCH=amd64 go build -v -o artifacts/molt.darwin.amd64 .
-      - name: Build OSX ARM
-        run: GOOS=darwin GOARCH=arm64 go build -v -o artifacts/molt.darwin.arm64 .
-      - name: Publish to release
-        uses: AButler/upload-release-assets@v2.0
-        with:
-          files: 'artifacts/*'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        workload_identity_provider: "${{ vars.WORKLOAD_IDENTITY_PROVIDER }}"
+        service_account: "${{ vars.GCP_SERVICE_ACCOUNT }}"
+    - name: Write the versions text file with updated binary links
+      if: ${{ github.event_name == 'release' }}
+      run: |
+        echo "" >> ./versions.txt
+        echo "" >> ./versions.txt
+        for i in $(ls artifacts); do 
+          if [[ ! $i == *"latest"* ]]; then
+            echo "${{ vars.BUCKET_URL }}/molt/cli/$i" >> ./versions.txt
+          fi
+        done
+        cp versions.txt ./artifacts/versions.txt
+        cat ./artifacts/versions.txt
+    - name: Generate the manifest
+      if: ${{ github.event_name == 'release' }}
+      run: go run ./climanifest --version-file ./artifacts/versions.txt --output-file ./artifacts/versions.html --template-file "./climanifest/climanifestHtml.tmpl" --title "MOLT Tools CLI Versions"
+    - name: Upload binaries and manifest to GCP bucket
+      id: 'upload-binaries'
+      uses: google-github-actions/upload-cloud-storage@v1
+      with:
+        path: 'artifacts'
+        destination: '${{ vars.GCS_BUCKET }}/molt/cli'
+        parent: false
+        headers: |-
+            cache-control:public, max-age=60 
+    - name: Output links
+      run: |
+        echo "CLI Binaries" >> $GITHUB_STEP_SUMMARY
+        for i in $(ls artifacts); do 
+          echo "${{ vars.BUCKET_URL }}/molt/cli/$i" >> $GITHUB_STEP_SUMMARY
+        done
+    - name: 'Set up Google Cloud SDK'
+      if: ${{ github.event_name == 'release' }}
+      uses: 'google-github-actions/setup-gcloud@v1'
+    - name: Invalidate CDN cache
+      if: ${{ github.event_name == 'release' }}
+      run: |
+        gcloud compute url-maps invalidate-cdn-cache molt-lms-release-artifacts-prod-default --path "/molt/cli/*" --async

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ gen:
 clean_artifacts:
 	cd ./artifacts && rm *
 
-build_cli:
+build_molt_cli:
 	mkdir -p ./artifacts
 	if test "$(version)" = "" ; then \
         echo "tag is not set, try running this command with a tag like 'make build_cli version=1.0.0'"; \

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,13 @@
 gen:
 	go generate ./...
+
+clean_artifacts:
+	cd ./artifacts && rm *
+
+build_cli:
+	mkdir -p ./artifacts
+	if test "$(version)" = "" ; then \
+        echo "tag is not set, try running this command with a tag like 'make build_cli version=1.0.0'"; \
+        exit 1; \
+    fi
+	./scripts/build-cross-platform.sh ./ ./artifacts/molt $(version)

--- a/climanifest/README.md
+++ b/climanifest/README.md
@@ -1,0 +1,9 @@
+# CLI Manifest Generator
+
+This Go program generates an HTML page with the relevant versions and download links. It pulls from the versions file that exists at https://molt.cockroachdb.com/molt/cli/versions.txt or defaults to base-versions.txt.
+
+In order to use:
+
+```
+go run . --version-file "base-versions.txt" --title "Versions"
+```

--- a/climanifest/base-versions.txt
+++ b/climanifest/base-versions.txt
@@ -1,0 +1,6 @@
+https://molt.cockroachdb.com/molt/cli/molt-latest.darwin-amd64.tgz
+https://molt.cockroachdb.com/molt/cli/molt-latest.darwin-arm64.tgz
+https://molt.cockroachdb.com/molt/cli/molt-latest.linux-amd64.tgz
+https://molt.cockroachdb.com/molt/cli/molt-latest.linux-arm64.tgz
+https://molt.cockroachdb.com/molt/cli/molt-latest.windows-amd64.tgz
+https://molt.cockroachdb.com/molt/cli/molt-latest.windows-arm64.tgz

--- a/climanifest/climanifest.go
+++ b/climanifest/climanifest.go
@@ -1,0 +1,132 @@
+// Copyright 2022 Cockroach Labs Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"html/template"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+)
+
+type version struct {
+	Name string
+	Link string
+}
+
+type renderData struct {
+	Title    string
+	Versions []*version
+}
+
+const (
+	inputName  = "versions.txt"
+	tmplName   = "climanifestHtml.tmpl"
+	outputName = "versions.html"
+	titleName  = ""
+)
+
+var versionFile string
+var outputFile string
+var templateFile string
+var title string
+
+func init() {
+	flag.StringVar(&versionFile, "version-file", inputName, "the input versions file")
+	flag.StringVar(&outputFile, "output-file", outputName, "the output version file")
+	flag.StringVar(&templateFile, "template-file", tmplName, "the template file")
+	flag.StringVar(&title, "title", titleName, "the title for the manifest")
+	flag.Parse()
+}
+
+func readFromVersions(versionsFile string) ([]*version, error) {
+	file, err := os.Open(versionsFile)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	seen := map[string]bool{}
+	versions := []*version{}
+
+	// Loop through the lines
+	for scanner.Scan() {
+		urlStr := strings.TrimSpace(scanner.Text())
+
+		if urlStr == "" || !strings.Contains(urlStr, ".tgz") {
+			continue
+		}
+		// Do something with the line, e.g., print it
+
+		u, err := url.Parse(urlStr)
+		if err != nil {
+			fmt.Println("Error parsing URL:", err)
+			return nil, err
+		}
+
+		// If we've already seen the path, we should skip.
+		if _, ok := seen[u.Path]; ok {
+			fmt.Printf("Skipping, already saw path: %s\n", u.Path)
+			continue
+		}
+
+		seen[u.Path] = true
+		versions = append(versions, &version{
+			Name: path.Base(u.Path),
+			Link: urlStr,
+		})
+	}
+
+	return versions, nil
+}
+
+func main() {
+	versions, err := readFromVersions(versionFile)
+	if err != nil {
+		panic(err)
+	}
+
+	funcMap := template.FuncMap{
+		"dec":     func(i int) int { return i - 1 },
+		"replace": strings.ReplaceAll,
+	}
+	var tmplFile = templateFile
+	tmpl, err := template.New(tmplName).Funcs(funcMap).ParseFiles(tmplFile)
+	if err != nil {
+		panic(err)
+	}
+	var f *os.File
+	f, err = os.Create(outputFile)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(f, renderData{
+		Title:    title,
+		Versions: versions,
+	})
+	if err != nil {
+		panic(err)
+	}
+	err = f.Close()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/climanifest/climanifestHtml.tmpl
+++ b/climanifest/climanifestHtml.tmpl
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        a {
+            display: block;
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>{{ .Title }}</h1>
+    {{ range .Versions }}
+    <a href="{{ .Link }}">{{ .Name }}</a>
+    {{ end }}
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
-	github.com/go-ole/go-ole v1.2.4 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,7 @@ github.com/danjacques/gofslock v0.0.0-20191023191349-0a45f885bc37/go.mod h1:DC3J
 github.com/dave/dst v0.27.2 h1:4Y5VFTkhGLC1oddtNwuxxe36pnyLxMFXT51FOzH8Ekc=
 github.com/dave/dst v0.27.2/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
 github.com/dave/jennifer v1.5.0 h1:HmgPN93bVDpkQyYbqhCHj5QlgvUkvEOzMyEvKLgCRrg=
+github.com/dave/jennifer v1.5.0/go.mod h1:4MnyiFIlZS3l5tSDn8VnzE6ffAhYBMB2SZntBsZGUok=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -295,9 +296,11 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
-github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
+github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -321,6 +324,7 @@ github.com/go-sql-driver/mysql v1.7.2-0.20230527164328-99976f4f587d h1:YBEDrTzME
 github.com/go-sql-driver/mysql v1.7.2-0.20230527164328-99976f4f587d/go.mod h1:6gYm/zDt3ahdnMVTPeT/LfoBFsws1qZm5yI6FmVjB14=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
@@ -384,6 +388,7 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
@@ -410,6 +415,7 @@ github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIG
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -653,10 +659,12 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo/v2 v2.9.7 h1:06xGQy5www2oN160RtEZoTvnP2sPhEfePYmCDc2szss=
+github.com/onsi/ginkgo/v2 v2.9.7/go.mod h1:cxrmXWykAwTwhQsJOPfdIDiJ+l2RYq7U8hFU+M/1uw0=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
+github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -792,6 +800,7 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v3.21.2+incompatible h1:U+YvJfjCh6MslYlIAXvPtzhW3YZEtc9uncueUNpD/0A=
 github.com/shirou/gopsutil v3.21.2+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
@@ -807,6 +816,7 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.2 h1:oxx1eChJGI6Uks2ZC4W1zpLlVgqB8ner4EuQwV4Ik1Y=
+github.com/sirupsen/logrus v1.9.2/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
@@ -856,6 +866,7 @@ github.com/the42/cartconvert v0.0.0-20131203171324-aae784c392b8/go.mod h1:fWO/ms
 github.com/thediveo/enumflag/v2 v2.0.4 h1:CPez2ZDJMkJ0iPiueJ6/vwsFeFy+w5kIJNFwxKPSUGo=
 github.com/thediveo/enumflag/v2 v2.0.4/go.mod h1:K5VGebAdhHGZyVprL7WEnEJ3CA16YzWhDH2ERwddA0I=
 github.com/thediveo/success v1.0.1 h1:NVwUOwKUwaN8szjkJ+vsiM2L3sNBFscldoDJ2g2tAPg=
+github.com/thediveo/success v1.0.1/go.mod h1:AZ8oUArgbIsCuDEWrzWNQHdKnPbDOLQsWOFj9ynwLt0=
 github.com/thoas/go-funk v0.8.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=

--- a/scripts/build-cross-platform.sh
+++ b/scripts/build-cross-platform.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+package=$1
+original_package_output_name=$2
+version=$3
+if [[ -z "$package" || -z "package_name" ]]; then
+  echo "usage: $0 <package-name> <package-output-name> <version>"
+  exit 1
+fi
+	
+platforms=("windows/amd64" "windows/arm64" "darwin/arm64" "darwin/amd64" "linux/amd64" "linux/arm64")
+
+for platform in "${platforms[@]}"
+do
+	platform_split=(${platform//\// })
+	GOOS=${platform_split[0]}
+	GOARCH=${platform_split[1]}
+	output_name=$original_package_output_name'-'$version'.'$GOOS'-'$GOARCH'.tgz'
+	latest_output_name=$original_package_output_name'-latest.'$GOOS'-'$GOARCH'.tgz'
+	if [ $GOOS = "windows" ]; then
+		package_output_name=$original_package_output_name'.exe'
+	else
+		package_output_name=$original_package_output_name
+	fi	
+
+	# Build for the given OS and architecture.
+	echo "Building for $platform."
+	env GOOS=$GOOS GOARCH=$GOARCH go build -o $package_output_name $package
+	if [ $? -ne 0 ]; then
+   		echo "Failed to build for $platform"
+		exit 1
+	fi
+
+	# Compress for the given build package.
+	original_path=$(pwd)
+	cd $(dirname $package_output_name)
+	tar -cvzf $(basename $output_name) $(basename $package_output_name)
+	tar -cvzf $(basename $latest_output_name) $(basename $package_output_name)
+	rm $(basename $package_output_name)
+
+	echo "Finished building for $output_name."
+	cd $original_path
+done


### PR DESCRIPTION
**molt: added in script to build tool cross platform and updated Makefile entries**
Added in a helper script so that we build out the tooling in a more standardized way.

Also updated `go-ole` to the latest version in order to address build issues with Windows + Arm64.

**climanifest: added in manifest generation code that outputs an HTML manifest for versions**
This is the common package that will be used across MOLT tools to generate manifest for binaries.

**.github/workflows: added release-cli workflow steps to upload to GCS bucket**
Added logic to run cross platform builds, update the manifest, and upload the manifest and new builds to GCS. Invalidates the cache afterwards.

Removed legacy release steps.