### PR TITLE
Verify: Support additional MySQL types

### DIFF
--- a/mysqlconv/data_type.go
+++ b/mysqlconv/data_type.go
@@ -37,7 +37,7 @@ func DataTypeToOID(dataType, columnType string) oid.Oid {
 		return oid.T_bytea
 	case "varbinary":
 		return oid.T_bytea
-	case "blob", "text":
+	case "blob", "text", "mediumtext", "longtext":
 		return oid.T_text
 	case "json":
 		return oid.T_jsonb
@@ -46,6 +46,6 @@ func DataTypeToOID(dataType, columnType string) oid.Oid {
 	case "set":
 		panic(errors.Newf("enums not yet handled"))
 	default:
-		panic(errors.Newf("unhandled type %s"))
+		panic(errors.Newf("unhandled data type %s, column type %s", dataType, columnType))
 	}
 }

--- a/mysqlconv/testdata/datatype/datatype.ddt
+++ b/mysqlconv/testdata/datatype/datatype.ddt
@@ -1,6 +1,7 @@
 from_create_table
 CREATE TABLE da_test_table (
-    tinyint_test TINYINT,
+    tiny_int_test TINYINT,
+    tinyint4_test TINYINT(4),
     smallint_test SMALLINT,
     int_test INTEGER,
     largeint_test BIGINT,
@@ -9,6 +10,8 @@ CREATE TABLE da_test_table (
     date_test DATE,
     bit_test BIT,
     text_test TEXT,
+    medtext_test MEDIUMTEXT,
+    longtext_test LONGTEXT,
     varchar_test VARCHAR(20),
     float_test FLOAT,
     bigfloat_test DOUBLE,
@@ -17,7 +20,8 @@ CREATE TABLE da_test_table (
     enum_test ENUM('a', 'b', 'c')
 )
 ----
-tinyint_test: int2
+tiny_int_test: int2
+tinyint4_test: int2
 smallint_test: int2
 int_test: int4
 largeint_test: int
@@ -26,6 +30,8 @@ timestamp_test: timestamptz
 date_test: date
 bit_test: varbit
 text_test: string
+medtext_test: string
+longtext_test: string
 varchar_test: varchar
 float_test: float4
 bigfloat_test: float


### PR DESCRIPTION
This commit adds support for the mediumtext and longtext types in MySQL. They will be tranlsated to the string type in CRDB

This commit also fixes the panic error message for unhandled types to properly show which data type caused the problem.

Release note: Additional supported MySQL types