### PR TITLE
.github/workflows: automate the docs creation ticket after release

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# -u: we want the variables to be properly assigned.
+# -o pipefail: we want to test the result of pipes.
+# No -e because we have failing commands and that's OK.
+set -uo pipefail
+
+grep=${GREP:-grep}
+awk=${AWK:-awk}
+sed=${SED:-sed}
+
+notes=($($grep -iE '^release note' "$1"))
+
+if [ 0 = ${#notes[*]} ]; then
+    echo "No release note specified."
+    echo "Try: 'Release Note: ...'" >&2
+    echo >&2
+    exit 1
+fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,3 +87,52 @@ jobs:
       if: ${{ github.event_name == 'release' }}
       run: |
         gcloud compute url-maps invalidate-cdn-cache molt-lms-release-artifacts-prod-default --path "/molt/cli/*" --async
+
+  create-docs-ticket:
+    if: ${{ github.event_name == 'release' }}
+    needs: [release-cli]
+    environment: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Extract short log, ref, and date
+        id: extract
+        run: | 
+          echo "Ref: ${GITHUB_REF_NAME#v}"
+          echo "tag=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          echo "release_date=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+          # We are sorting the tags by semver and getting the second highest because that is
+          # the latest released version. The highest semver is the one currently being released
+          # since the tagging happens right before this runs.
+          latest_tag=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -2 | head -1)
+          echo "$latest_tag is the latest tag"
+
+          # Filters all commits from latest tag to now, looks for release notes, excludes empty ones, and adds a dash at the front of each line.
+          output=$(git log $latest_tag..HEAD | grep -i "release note:" | grep -vi 'release note: none' | sed 's/^ *Release Note: *//I' | sed 's/^/- /')
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "shortlog<<$EOF" >> $GITHUB_OUTPUT
+          echo "'$output'" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - name: Log out the git short log
+        run: |
+          echo ${{steps.extract.outputs.shortlog}}
+      - name: Login to JIRA
+        uses: atlassian/gajira-login@master
+        env:
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ vars.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      - name: Create DOC JIRA ticket
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: DOC
+          issuetype: Docs
+          summary: MOLT Fetch/Verify (${{steps.extract.outputs.release_date}}) release ${{steps.extract.outputs.tag}}
+          description: ${{steps.extract.outputs.shortlog}}
+          # 10310 is product area - Migrations. 10175 is doc type - release notes. Assignee is Ryan Kuo.
+          fields: '{"customfield_10310": {"id": "11464"}, "assignee": {"id": "5d815e4401e2cb0c301faf7e"}, "customfield_10175": {"id": "11432"}}'
+      - name: Log created issue
+        run: echo "Issue ${{ vars.JIRA_BASE_URL }}/browse/${{ steps.create.outputs.issue }} was created"

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ build_molt_cli:
         exit 1; \
     fi
 	./scripts/build-cross-platform.sh ./ ./artifacts/molt $(version)
+
+sync_hooks:
+	cp -a .githooks/ .git/hooks/

--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ molt fetch \
 
 ## Local Setup
 
+### Setup Git Hooks
+
+In order to enforce good developer practices, there are Git hooks that must be synced to your local directory. To do this, run: `make sync_hooks`. Right now, this supports making sure that each commit has a `Release Note:`.
+
 ### Running Tests
 
 - Ensure a local postgres instance is setup and can be logged in using


### PR DESCRIPTION
Gets the log between the head of the branch and the latest release tag. Then creates a ticket with the relevant fields, using the official JIRA GH action helper.

Resolves: CC-26297, CC-26370
Release Note: Release notes are now more structured and describe customer implications more clearly. These notes are now picked up by automation and will be reflected in documentation pages.

Test run: https://github.com/cockroachdb/molt/actions/runs/7038865628
Created ticket: https://cockroachlabs.atlassian.net/browse/DOC-9302