### PR TITLE
README: added specific MySQL setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ Substitute the following encoded password in your original connection url string
 %3B%40%3B
 ```
 
+## Database-specific setup
+
+### MySQL
+
+A prerequisite of using `molt fetch` with MySQL is that GTID consistency must be enabled. This is necessary for returning the `cdc_cursor`. To enable GTID, pass two flags to the `mysql` start command or define them in `mysl.cnf`:
+
+```
+--gtid-mode=ON
+--enforce-gtid-consistency=ON
+```
+
+Additionally, disable `ONLY_FULL_GROUP_BY`:
+
+```
+// Inside the MySQL shell
+SET PERSIST sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
+```
+
+References:
+[MySQL Docs for Enabling GTID](https://dev.mysql.com/doc/refman/8.0/en/replication-gtids-howto.html)
+[Enabling for AWS RDS MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql-replication-gtid.html)
+
 ## MOLT Verify
 
 `molt verify` does the following:


### PR DESCRIPTION
Added details about setting up replication using GTIDs so that people can have their MySQL instance ready for use with MOLT fetch. GTID is required because it is a necessary step for returning the cdc_cursor.

Resolves: CC-26359
Release Note: README for MOLT fetch is now updated with MySQL specific setup instructions that instruct users to set up replication using GTID, which is required for MOLT fetch to operate with MySQL correctly. This change will clarify confusion users had about MOLT fetch instructions not working because of a missing pre-condition step.