### PR TITLE
cmdutil: refined logging scheme by adding timestamps, structured logging as a default, and option to write to a log file

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -24,6 +24,7 @@ func Command() *cobra.Command {
 		localPath               string
 		localPathListenAddr     string
 		localPathCRDBAccessAddr string
+		logFile                 string
 		directCRDBCopy          bool
 		cfg                     fetch.Config
 	)
@@ -34,7 +35,7 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
-			logger, err := cmdutil.Logger()
+			logger, err := cmdutil.Logger(logFile)
 			if err != nil {
 				return err
 			}
@@ -104,6 +105,12 @@ func Command() *cobra.Command {
 		},
 	}
 
+	cmd.PersistentFlags().StringVar(
+		&logFile,
+		"log-file",
+		"",
+		"If set, writes to the log file specified. Otherwise, only writes to stdout.",
+	)
 	cmd.PersistentFlags().BoolVar(
 		&directCRDBCopy,
 		"direct-copy",

--- a/cmd/internal/cmdutil/logger.go
+++ b/cmd/internal/cmdutil/logger.go
@@ -1,16 +1,23 @@
 package cmdutil
 
 import (
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
 
 type loggerConfig struct {
-	level string
+	level            string
+	useConsoleWriter bool
 }
 
 var loggerConfigInst = loggerConfig{
-	level: zerolog.InfoLevel.String(),
+	level:            zerolog.InfoLevel.String(),
+	useConsoleWriter: false,
 }
 
 func RegisterLoggerFlags(cmd *cobra.Command) {
@@ -20,13 +27,39 @@ func RegisterLoggerFlags(cmd *cobra.Command) {
 		loggerConfigInst.level,
 		"Level to log at (maps to zerolog.Level).",
 	)
+	cmd.PersistentFlags().BoolVar(
+		&loggerConfigInst.useConsoleWriter,
+		"use-console-writer",
+		loggerConfigInst.useConsoleWriter,
+		"Use the console writer, which has cleaner log output but introduces more latency (defaults to false, which logs as structured JSON).",
+	)
 }
 
-func Logger() (zerolog.Logger, error) {
-	logger := zerolog.New(zerolog.NewConsoleWriter())
+func Logger(fileName string) (zerolog.Logger, error) {
+	var writer io.Writer = os.Stdout
+	if loggerConfigInst.useConsoleWriter {
+		writer = zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
+			w.TimeFormat = time.RFC3339
+		})
+	}
+
+	if fileName != "" {
+		dir := filepath.Dir(fileName)
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return zerolog.Logger{}, err
+		}
+
+		f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+		if err != nil {
+			return zerolog.Logger{}, err
+		}
+		writer = io.MultiWriter(writer, f)
+	}
+
+	logger := zerolog.New(writer)
 	lvl, err := zerolog.ParseLevel(loggerConfigInst.level)
 	if err != nil {
 		return logger, err
 	}
-	return logger.Level(lvl), err
+	return logger.Level(lvl).With().Timestamp().Logger(), err
 }

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -36,6 +36,7 @@ func Command() *cobra.Command {
 		}
 		verifyLimitRowsPerSecond int
 		verifyRows               bool
+		verifyLogFile            string
 	)
 
 	cmd := &cobra.Command{
@@ -43,7 +44,7 @@ func Command() *cobra.Command {
 		Short: "Verify table schemas and row data align.",
 		Long:  `Verify ensure table schemas and row data between the two databases are aligned.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger, err := cmdutil.Logger()
+			logger, err := cmdutil.Logger(verifyLogFile)
 			if err != nil {
 				return err
 			}
@@ -90,7 +91,12 @@ func Command() *cobra.Command {
 			return nil
 		},
 	}
-
+	cmd.PersistentFlags().StringVar(
+		&verifyLogFile,
+		"log-file",
+		"",
+		"If set, writes to the log file specified. Otherwise, only writes to stdout.",
+	)
 	cmd.PersistentFlags().IntVar(
 		&verifyConcurrency,
 		"concurrency",


### PR DESCRIPTION
Resolves: CC-26366, CC-26376
Release Note: Logging for the Fetch and Verify tooling is now defaulted to structured JSON logging which contains at least the message, level, and formatted time string. There is now a flag that can set the output to use prettier console writing that has colored output and human readable output. The structured logging is preferred as a default because it's easier to parse by log ingestion tools and is more efficient to output by the application. Also, customers can now define log files to write their task/data logs for fetch and verify. If left empty, the molt tool will only write to stdout, which is more efficient.

**Decisions**
- Defaulted to not writing out to a log file + stdout because it's less performant; most customers will probably want to just pick up from stdout anyways
- Gave the option to write to a log file if needed so that logs can be reviewed after the fact
- Defaulted to structured logging because it's more friendly with log obs tools
- Went with time strings that match RFC3339 because standard and includes timestamp plus GMT adjustment

**Logging Output**
As a note, the structured logging is less human readable, but more structured and efficient, which is great for log processing tools. Usually these will be parsed into fields from Grafana or Datadog or Splunk anyways.

The pretty logging is there so that it's easier to read and see output. Helpful for debugging or manual monitoring. But console writing is more inefficient.

Structured Logging (default):
```
{"level":"info","table":"public.employees","num_rows":200000,"time":"2023-12-05T12:26:25-08:00","message":"row import status"}
{"level":"info","table":"public.employees","num_rows":200000,"export_duration":19946.218792,"time":"2023-12-05T12:26:44-08:00","message":"data extraction from source complete"}
{"level":"info","table":"public.employees","time":"2023-12-05T12:26:44-08:00","message":"starting data import on target"}
{"level":"info","table":"public.employees","duration":10346.895667,"time":"2023-12-05T12:26:55-08:00","message":"table COPY complete"}
{"level":"info","table":"public.employees","net_duration":30306.384459,"import_duration":10346.895667,"cdc_cursor":"0/3DB30A0","time":"2023-12-05T12:26:55-08:00","message":"data import on target for table complete"}
{"level":"info","num_tables":1,"tables":["public.employees"],"cdc_cursor":"0/3DB30A0","time":"2023-12-05T12:26:55-08:00","message":"fetch complete"}
```

(BEFORE) Pretty Logging (can be set with a flag):
```
2023-12-05T12:33:15-08:00 INF default compression to none
2023-12-05T12:33:15-08:00 INF checking database details
2023-12-05T12:33:15-08:00 INF found matching table source_table=public.employees target_table=public.employees
2023-12-05T12:33:15-08:00 INF verifying common tables
2023-12-05T12:33:15-08:00 INF establishing snapshot
2023-12-05T12:33:15-08:00 INF starting fetch cdc_cursor=0/3DB30A0 num_tables=1
2023-12-05T12:33:15-08:00 INF data extraction phase starting table=public.employees
2023-12-05T12:33:17-08:00 INF row import status num_rows=100000 table=public.employees
2023-12-05T12:33:17-08:00 INF row import status num_rows=200000 table=public.employees
2023-12-05T12:33:39-08:00 INF data extraction from source complete export_duration=23651.084375 num_rows=200000 table=public.employees
2023-12-05T12:33:39-08:00 INF starting data import on target table=public.employees
2023-12-05T12:33:43-08:00 INF table COPY complete duration=4560.166334 table=public.employees
2023-12-05T12:33:43-08:00 INF data import on target for table complete cdc_cursor=0/3DB30A0 import_duration=4560.166334 net_duration=28217.138 table=public.employees
2023-12-05T12:33:43-08:00 INF fetch complete cdc_cursor=0/3DB30A0 num_tables=1 tables=["public.employees"]
```