### PR TITLE
fetch: marked certain flags as mutually exclusive so that multiple modes cannot be run at once

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -114,16 +114,16 @@ func Command() *cobra.Command {
 		"If set, writes to the log file specified. Otherwise, only writes to stdout.",
 	)
 	cmd.PersistentFlags().BoolVar(
-		&directCRDBCopy,
-		"direct-copy",
-		false,
-		"Enables direct copy mode, which copies data directly from source to target without using an intermediate store.",
-	)
-	cmd.PersistentFlags().BoolVar(
 		&cfg.Cleanup,
 		"cleanup",
 		false,
 		"Whether any created resources should be deleted. Ignored if in direct-copy mode.",
+	)
+	cmd.PersistentFlags().BoolVar(
+		&directCRDBCopy,
+		"direct-copy",
+		false,
+		"Enables direct copy mode, which copies data directly from source to target without using an intermediate store.",
 	)
 	cmd.PersistentFlags().BoolVar(
 		&cfg.Live,
@@ -143,6 +143,7 @@ func Command() *cobra.Command {
 		0,
 		"If set, number of rows before the source data is flushed to intermediate files.",
 	)
+
 	cmd.PersistentFlags().IntVar(
 		&cfg.Concurrency,
 		"concurrency",
@@ -185,6 +186,8 @@ func Command() *cobra.Command {
 		"",
 		"Address of data that CockroachDB can access to import from a local store (defaults to local-path-listen-addr).",
 	)
+	cmd.MarkFlagsMutuallyExclusive("s3-bucket", "gcp-bucket", "local-path")
+
 	cmd.PersistentFlags().BoolVar(
 		&cfg.Truncate,
 		"truncate",


### PR DESCRIPTION
Release Note: Marked the s3-bucket, gcp-bucket, and local-path flags as mutually exclusive because they all represent different intermediary stores. Also, marked settings for the flush rows and byte size so that only one policy can apply at a time.

Test Results:
```
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . fetch --source "ya" --target "nah" --flush-size 10 --flush-rows 100                  
Error: if any flags in the group [flush-size flush-rows] are set none of the others can be; [flush-rows flush-size] were all set

(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . fetch --source "ya" --target "nah" --s3-bucket s3 --gcp-bucket gcp 
Error: if any flags in the group [s3-bucket gcp-bucket local-path] are set none of the others can be; [gcp-bucket s3-bucket] were all set

(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . fetch --source "ya" --target "nah" --s3-bucket s3 --gcp-bucket gcp --local-path 10
Error: if any flags in the group [s3-bucket gcp-bucket local-path] are set none of the others can be; [gcp-bucket local-path s3-bucket] were all set

(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . fetch --source "ya" --target "nah" --s3-bucket s3  --local-path 10 
Error: if any flags in the group [s3-bucket gcp-bucket local-path] are set none of the others can be; [local-path s3-bucket] were all set
```