### PR TITLE
molt: added in logger field for type to differentiate between task, summary, and data logging

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/molt/dbconn"
 	"github.com/cockroachdb/molt/fetch"
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
+	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag/v2"
 	"golang.org/x/oauth2/google"
@@ -34,8 +35,7 @@ func Command() *cobra.Command {
 		Long:  `Imports data from source directly into target tables.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-
-			logger, err := cmdutil.Logger(logFile)
+			logger, err := moltlogger.Logger(logFile)
 			if err != nil {
 				return err
 			}
@@ -228,8 +228,8 @@ func Command() *cobra.Command {
 		"compression",
 		"Compression type (default/gzip/none) to use (IMPORT INTO mode only).",
 	)
+	moltlogger.RegisterLoggerFlags(cmd)
 	cmdutil.RegisterDBConnFlags(cmd)
-	cmdutil.RegisterLoggerFlags(cmd)
 	cmdutil.RegisterNameFilterFlags(cmd)
 	cmdutil.RegisterMetricsFlags(cmd)
 	return cmd

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/molt/cmd/internal/cmdutil"
+	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/cockroachdb/molt/retry"
 	"github.com/cockroachdb/molt/verify"
 	"github.com/cockroachdb/molt/verify/inconsistency"
@@ -38,7 +39,7 @@ func Command() *cobra.Command {
 		}
 		verifyLimitRowsPerSecond int
 		verifyRows               bool
-		verifyLogFile            string
+		logFile                  string
 	)
 
 	cmd := &cobra.Command{
@@ -46,7 +47,7 @@ func Command() *cobra.Command {
 		Short: "Verify table schemas and row data align.",
 		Long:  `Verify ensure table schemas and row data between the two databases are aligned.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger, err := cmdutil.Logger(verifyLogFile)
+			logger, err := moltlogger.Logger(logFile)
 			if err != nil {
 				return err
 			}
@@ -94,7 +95,7 @@ func Command() *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(
-		&verifyLogFile,
+		&logFile,
 		"log-file",
 		"",
 		"If set, writes to the log file specified. Otherwise, only writes to stdout.",
@@ -216,8 +217,8 @@ func Command() *cobra.Command {
 			panic(err)
 		}
 	}
+	moltlogger.RegisterLoggerFlags(cmd)
 	cmdutil.RegisterDBConnFlags(cmd)
-	cmdutil.RegisterLoggerFlags(cmd)
 	cmdutil.RegisterNameFilterFlags(cmd)
 	cmdutil.RegisterMetricsFlags(cmd)
 	return cmd

--- a/fetch/copy.go
+++ b/fetch/copy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
 	"github.com/cockroachdb/molt/fetch/internal/dataquery"
+	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/rs/zerolog"
 )
 
@@ -23,6 +24,7 @@ func Copy(
 	table dbtable.VerifiedTable,
 	resources []datablobstorage.Resource,
 ) (CopyResult, error) {
+	dataLogger := moltlogger.GetDataLogger(logger)
 	ret := CopyResult{
 		StartTime: time.Now(),
 	}
@@ -30,7 +32,7 @@ func Copy(
 	conn := baseConn.(*dbconn.PGConn).Conn
 
 	for i, resource := range resources {
-		logger.Debug().
+		dataLogger.Debug().
 			Int("idx", i+1).
 			Msgf("reading resource")
 		if err := func() error {
@@ -38,7 +40,7 @@ func Copy(
 			if err != nil {
 				return err
 			}
-			logger.Debug().
+			dataLogger.Debug().
 				Int("idx", i+1).
 				Msgf("running copy from resource")
 			if _, err := conn.PgConn().CopyFrom(
@@ -55,7 +57,7 @@ func Copy(
 	}
 
 	ret.EndTime = time.Now()
-	logger.Info().
+	dataLogger.Info().
 		Dur("duration", ret.EndTime.Sub(ret.StartTime)).
 		Msgf("table COPY complete")
 	return ret, nil

--- a/fetch/csv_pipe.go
+++ b/fetch/csv_pipe.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/cockroachdb/molt/dbtable"
+	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
@@ -54,6 +55,7 @@ func (p *csvPipe) Pipe(tn dbtable.Name) error {
 	r := csv.NewReader(p.in)
 	r.ReuseRecord = true
 	m := importedRows.WithLabelValues(tn.SafeString())
+	dataLogger := moltlogger.GetDataLogger(p.logger)
 	for {
 		record, err := r.Read()
 		if err != nil {
@@ -67,7 +69,7 @@ func (p *csvPipe) Pipe(tn dbtable.Name) error {
 		p.numRows++
 		m.Inc()
 		if p.numRows%100000 == 0 {
-			p.logger.Info().Int("num_rows", p.numRows).Msgf("row import status")
+			dataLogger.Info().Int("num_rows", p.numRows).Msgf("row import status")
 		}
 		for _, s := range record {
 			p.currSize += len(s) + 1

--- a/fetch/import_table.go
+++ b/fetch/import_table.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
 	"github.com/cockroachdb/molt/fetch/internal/dataquery"
+	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/cockroachdb/molt/retry"
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
@@ -59,6 +60,7 @@ func reportImportTableProgress(
 	curTime time.Time,
 	testing bool,
 ) error {
+	dataLogger := moltlogger.GetDataLogger(logger)
 	curTimeUTC := curTime.UTC().Format("2006-01-02T15:04:05")
 	r, err := retry.NewRetry(retry.Settings{
 		InitialBackoff: 10 * time.Second,
@@ -98,7 +100,7 @@ func reportImportTableProgress(
 		} else if p[0].FractionCompleted != 1 {
 			frac := p[0].FractionCompleted
 			if frac != 0.0 && prevVal != frac {
-				logger.Info().Str("completion", fmt.Sprintf("%.2f%%", frac*100)).Msgf("progress")
+				dataLogger.Info().Str("completion", fmt.Sprintf("%.2f%%", frac*100)).Msgf("progress")
 			}
 
 			prevVal = p[0].FractionCompleted

--- a/utils/time.go
+++ b/utils/time.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+func FormatDurationToTimeString(duration time.Duration) string {
+	hours := int(duration.Hours())
+	minutes := int(duration.Minutes()) % 60
+	seconds := int(duration.Seconds()) % 60
+
+	// Hours are rounded to 3 places because there could be table loads that
+	// take weeks, which could be hundreds of hours.
+	// We don't show milliseconds because it's such a minimal amount of time
+	// and is unlikely for most production tables. Also, if folks want
+	// milliseconds, we are still logging out the milliseconds data side by side.
+	return fmt.Sprintf("%03dh %02dm %02ds", hours, minutes, seconds)
+}

--- a/utils/time_test.go
+++ b/utils/time_test.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatMillisecondsToTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    time.Duration
+		expected string
+	}{
+		{
+			name:     "seconds duration",
+			input:    20 * time.Second,
+			expected: "000h 00m 20s",
+		},
+		{
+			name:     "minutes + seconds duration",
+			input:    80 * time.Second,
+			expected: "000h 01m 20s",
+		},
+		{
+			name:     "minutes duration",
+			input:    20 * time.Minute,
+			expected: "000h 20m 00s",
+		},
+		{
+			name:     "hours + minutes duration",
+			input:    80 * time.Minute,
+			expected: "001h 20m 00s",
+		},
+		{
+			name:     "hours duration",
+			input:    20 * time.Hour,
+			expected: "020h 00m 00s",
+		},
+		{
+			name:     "hours + minutes + seconds duration",
+			input:    80*time.Minute + 10*time.Second,
+			expected: "001h 20m 10s",
+		},
+		{
+			name:     "weeks duration",
+			input:    24 * 7 * 2 * time.Hour,
+			expected: "336h 00m 00s",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			val := FormatDurationToTimeString(tc.input)
+			require.Equal(t, tc.expected, val)
+		})
+	}
+}


### PR DESCRIPTION
Added in logger types and Zerolog log context so that logs can be tagged with different contextual information. Also added utility methods that allow a user to retrieve a summary or data logger from their base logger.

Resolves: CC-26366
Release Note: Added tagging for summary and data logs so that customers can filter by "summary" or "data" in a variety of log processing tools and even grep in the command line. This solves the pain point of all the logs going to the same location without any differentiation. Now it's possible to view types of logs one at a time.

**Options Considered**
1. Making a base logger with the type already set => good solution and almost like the solution presented here, however, this led to duplicated `type` fields because zerolog doesn't de-duplicate repeated fields (https://github.com/rs/zerolog/issues/205)
2. New `MOLTLogger` type that contains multiple loggers inside of it => needs massive refactoring, worse DX, more complexity for little benefit
3. (CHOSEN) Making a base logger without the type set and helper methods to retrieve data and summary loggers => given that the minority logging case is summary or data logging, we have helpers that help us retrieve a tagged data/summary logger when we need it. An untagged, no `type` log is considered a task log. 
- We can grep for summary and data logs:
```
// Summary logs
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % cat task.log | grep '"summary"'
{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/3DB3098","time":"2023-12-08T16:55:24-08:00","message":"starting fetch"}
{"level":"info","table":"public.employees","type":"summary","num_rows":200000,"export_duration":2068.466084,"time":"2023-12-08T16:55:26-08:00","message":"data extraction from source complete"}
{"level":"info","table":"public.employees","type":"summary","net_duration":5464.5905,"import_duration":3328.998625,"export_duration":2068.466084,"num_rows":200000,"cdc_cursor":"0/3DB3098","time":"2023-12-08T16:55:30-08:00","message":"data import on target for table complete"}
{"level":"info","type":"summary","num_tables":1,"tables":["public.employees"],"cdc_cursor":"0/3DB3098","time":"2023-12-08T16:55:30-08:00","message":"fetch complete"}

// Data logs
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % cat task.log | grep '"data"'   
{"level":"info","table":"public.employees","type":"data","num_rows":100000,"time":"2023-12-08T16:55:25-08:00","message":"row import status"}
{"level":"info","table":"public.employees","type":"data","num_rows":200000,"time":"2023-12-08T16:55:25-08:00","message":"row import status"}

// Task logs
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % cat task.log | grep -v -e '"summary"' -e '"data"'
{"level":"info","time":"2023-12-08T16:55:24-08:00","message":"default compression to GZIP"}
{"level":"info","time":"2023-12-08T16:55:24-08:00","message":"checking database details"}
{"level":"info","source_table":"public.employees","target_table":"public.employees","time":"2023-12-08T16:55:24-08:00","message":"found matching table"}
{"level":"info","time":"2023-12-08T16:55:24-08:00","message":"verifying common tables"}
{"level":"info","time":"2023-12-08T16:55:24-08:00","message":"establishing snapshot"}
{"level":"info","table":"public.employees","time":"2023-12-08T16:55:24-08:00","message":"data extraction phase starting"}
{"level":"info","table":"public.employees","time":"2023-12-08T16:55:26-08:00","message":"truncating table"}
{"level":"info","table":"public.employees","time":"2023-12-08T16:55:26-08:00","message":"starting data import on target"}
```

Option 2 can be revisited if we ever need multiple output sources for our logger. For now, it's not worth the complexity.