### PR TITLE
verify: refactored the stats and inconsistency reporting so it's in exported from the inconsistency package

### DIFF
--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -73,7 +73,7 @@ func Command() *cobra.Command {
 				})
 			}
 
-			reporter.Report(inconsistency.StatusReport{Info: "verification in progress"})
+			logger.Info().Msg("verification in progress")
 			if err := verify.Verify(
 				ctx,
 				conns,
@@ -90,7 +90,8 @@ func Command() *cobra.Command {
 			); err != nil {
 				return errors.Wrapf(err, "error verifying")
 			}
-			reporter.Report(inconsistency.StatusReport{Info: "verification complete"})
+
+			logger.Info().Msg("verification complete")
 			return nil
 		},
 	}

--- a/verify/inconsistency/reporter.go
+++ b/verify/inconsistency/reporter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/molt/dbconn"
+	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/rs/zerolog"
 )
 
@@ -41,25 +42,28 @@ type LogReporter struct {
 }
 
 func (l LogReporter) Report(obj ReportableObject) {
+	dataLogger := moltlogger.GetDataLogger(l.Logger)
+	summaryLogger := moltlogger.GetSummaryLogger(l.Logger)
+
 	switch obj := obj.(type) {
 	case MissingTable:
-		l.Warn().
+		dataLogger.Warn().
 			Str("table_schema", string(obj.Schema)).
 			Str("table_name", string(obj.Table)).
-			Msgf("missing table detected")
+			Msgf("missing_table")
 	case ExtraneousTable:
-		l.Warn().
+		dataLogger.Warn().
 			Str("table_schema", string(obj.Schema)).
 			Str("table_name", string(obj.Table)).
-			Msgf("extraneous table detected")
+			Msgf("extraneous_table")
 	case MismatchingTableDefinition:
-		l.Warn().
+		dataLogger.Warn().
 			Str("table_schema", string(obj.Schema)).
 			Str("table_name", string(obj.Table)).
 			Str("mismatch_info", obj.Info).
-			Msgf("mismatching table definition")
+			Msgf("mismatching_table_def")
 	case StatusReport:
-		l.Info().Msg(obj.Info)
+		summaryLogger.Info().Msg(obj.Info)
 	case MismatchingRow:
 		sourceValues := zerolog.Dict()
 		targetVals := zerolog.Dict()
@@ -67,29 +71,29 @@ func (l LogReporter) Report(obj ReportableObject) {
 			targetVals = targetVals.Str(string(col), reportableVal(obj.TruthVals[i]))
 			sourceValues = sourceValues.Str(string(col), reportableVal(obj.TargetVals[i]))
 		}
-		l.Warn().
+		dataLogger.Warn().
 			Str("table_schema", string(obj.Schema)).
 			Str("table_name", string(obj.Table)).
 			Dict("source_values", targetVals).
 			Dict("target_values", sourceValues).
 			Strs("primary_key", zipPrimaryKeysForReporting(obj.PrimaryKeyValues)).
-			Msgf("mismatching row value")
+			Msgf("mismatching_row")
 	case MissingRow:
-		l.Warn().
+		dataLogger.Warn().
 			Str("table_schema", string(obj.Schema)).
 			Str("table_name", string(obj.Table)).
 			Strs("primary_key", zipPrimaryKeysForReporting(obj.PrimaryKeyValues)).
-			Msgf("missing row")
+			Msgf("missing_row")
 	case ExtraneousRow:
-		l.Warn().
+		dataLogger.Warn().
 			Str("table_schema", string(obj.Schema)).
 			Str("table_name", string(obj.Table)).
 			Strs("primary_key", zipPrimaryKeysForReporting(obj.PrimaryKeyValues)).
-			Msgf("extraneous row")
+			Msgf("extraneous_row")
 	default:
-		l.Error().
+		dataLogger.Error().
 			Str("type", fmt.Sprintf("%T", obj)).
-			Msgf("unknown object type")
+			Msgf("unknown_type")
 	}
 }
 

--- a/verify/inconsistency/stats.go
+++ b/verify/inconsistency/stats.go
@@ -1,0 +1,46 @@
+package inconsistency
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+)
+
+// RowStats includes all details about the total rows processed.
+type RowStats struct {
+	Schema        string
+	Table         string
+	NumVerified   int
+	NumSuccess    int
+	NumMissing    int
+	NumMismatch   int
+	NumExtraneous int
+	NumLiveRetry  int
+}
+
+func (s *RowStats) String() string {
+	return fmt.Sprintf(
+		"truth rows seen: %d, success: %d, missing: %d, mismatch: %d, extraneous: %d, live_retry: %d",
+		s.NumVerified,
+		s.NumSuccess,
+		s.NumMissing,
+		s.NumMismatch,
+		s.NumExtraneous,
+		s.NumLiveRetry,
+	)
+}
+
+// reportRunningSummary reports the number of total rows and errors seen
+// during the execution of verify.
+func reportRunningSummary(l zerolog.Logger, s RowStats, m string) {
+	l.Info().
+		Str("table_schema", s.Schema).
+		Str("table_name", s.Table).
+		Int("num_truth_rows", s.NumVerified).
+		Int("num_success", s.NumSuccess).
+		Int("num_missing", s.NumMissing).
+		Int("num_mismatch", s.NumMismatch).
+		Int("num_extraneous", s.NumExtraneous).
+		Int("num_live_retry", s.NumLiveRetry).
+		Msg(m)
+}

--- a/verify/testdata/datadriven/mysql/casing.ddt
+++ b/verify/testdata/datadriven/mysql/casing.ddt
@@ -10,7 +10,7 @@ CREATE TABLE tbl (id int primary key, t text, "xXx" text)
 
 verify
 ----
-{"level":"warn","table_schema":"public","table_name":"tbl","mismatch_info":"extraneous column xXx found","message":"mismatching table definition"}
-{"level":"warn","table_schema":"public","table_name":"tbl","mismatch_info":"missing column xxx","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"tbl","mismatch_info":"extraneous column xXx found","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"tbl","mismatch_info":"missing column xxx","message":"mismatching table definition"}
 {"level":"info","message":"starting verify on public.Tbl, shard 1/1"}
-{"level":"info","message":"finished row verification on public.Tbl (shard 1/1): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"\"Tbl\"","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.Tbl (shard 1/1)"}

--- a/verify/testdata/datadriven/mysql/collation.ddt
+++ b/verify/testdata/datadriven/mysql/collation.ddt
@@ -16,7 +16,7 @@ CREATE TABLE tbl (
 
 verify
 ----
-{"level":"warn","table_schema":"public","table_name":"tbl","mismatch_info":"PRIMARY KEY has a string field id has a different collation (mysql=latin1_swedish_ci, crdb=en_US.utf8) preventing verification","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"tbl","mismatch_info":"PRIMARY KEY has a string field id has a different collation (mysql=latin1_swedish_ci, crdb=en_US.utf8) preventing verification","message":"mismatching table definition"}
 
 exec source
 DROP TABLE tbl;
@@ -34,4 +34,4 @@ CREATE TABLE tbl (
 verify
 ----
 {"level":"info","message":"starting verify on public.tbl, shard 1/1"}
-{"level":"info","message":"finished row verification on public.tbl (shard 1/1): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"tbl","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.tbl (shard 1/1)"}

--- a/verify/testdata/datadriven/mysql/enum.ddt
+++ b/verify/testdata/datadriven/mysql/enum.ddt
@@ -26,5 +26,5 @@ INSERT INTO enum_table VALUES (1, 'a'), (2, 'c')
 verify
 ----
 {"level":"info","message":"starting verify on public.enum_table, shard 1/1"}
-{"level":"warn","table_schema":"public","table_name":"enum_table","source_values":{"s":"b"},"target_values":{"s":"c"},"primary_key":["2"],"message":"mismatching row value"}
-{"level":"info","message":"finished row verification on public.enum_table (shard 1/1): truth rows seen: 2, success: 1, missing: 0, mismatch: 1, extraneous: 0, live_retry: 0"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"enum_table","source_values":{"s":"b"},"target_values":{"s":"c"},"primary_key":["2"],"message":"mismatching row value"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"enum_table","num_truth_rows":2,"num_success":1,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.enum_table (shard 1/1)"}

--- a/verify/testdata/datadriven/mysql/row_mismatch.ddt
+++ b/verify/testdata/datadriven/mysql/row_mismatch.ddt
@@ -29,7 +29,7 @@ INSERT INTO test_table (id) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), 
 verify
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/1): truth rows seen: 10, success: 10, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":10,"num_success":10,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 exec all
 DROP TABLE test_table
@@ -67,16 +67,16 @@ INSERT INTO test_table (id) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), 
 verify
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/1): truth rows seen: 10, success: 10, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":10,"num_success":10,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 verify splits=3
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/3, range: [<beginning> - 4)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/3): truth rows seen: 3, success: 3, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/3)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/3, range: [4 - 7)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 2/3): truth rows seen: 3, success: 3, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/3)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/3, range: [7 - <end>]"}
-{"level":"info","message":"finished row verification on public.test_table (shard 3/3): truth rows seen: 4, success: 4, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":4,"num_success":4,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/3)"}
 
 exec all
 DROP TABLE test_table
@@ -121,12 +121,12 @@ INSERT INTO common_table VALUES
 verify
 ----
 {"level":"info","message":"starting verify on public.common_table, shard 1/1"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["50"],"message":"extraneous row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["125"],"message":"missing row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
-{"level":"info","message":"finished row verification on public.common_table (shard 1/1): truth rows seen: 6, success: 3, missing: 2, mismatch: 1, extraneous: 2, live_retry: 0"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["50"],"message":"extraneous row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["125"],"message":"missing row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":6,"num_success":3,"num_missing":2,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"message":"finished row verification on public.common_table (shard 1/1)"}
 
 # Verify with extraneous rows on source of truth.
 exec source
@@ -138,13 +138,13 @@ INSERT INTO common_table VALUES
 verify
 ----
 {"level":"info","message":"starting verify on public.common_table, shard 1/1"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["50"],"message":"extraneous row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["125"],"message":"missing row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["400"],"message":"missing row"}
-{"level":"info","message":"finished row verification on public.common_table (shard 1/1): truth rows seen: 7, success: 3, missing: 3, mismatch: 1, extraneous: 2, live_retry: 0"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["50"],"message":"extraneous row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["125"],"message":"missing row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["400"],"message":"missing row"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":7,"num_success":3,"num_missing":3,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"message":"finished row verification on public.common_table (shard 1/1)"}
 
 exec all
 DROP TABLE common_table

--- a/verify/testdata/datadriven/pg/collation.ddt
+++ b/verify/testdata/datadriven/pg/collation.ddt
@@ -16,7 +16,7 @@ CREATE TABLE tbl (
 
 verify
 ----
-{"level":"warn","table_schema":"public","table_name":"tbl","mismatch_info":"PRIMARY KEY has a string field id has a different collation (pg=C, crdb=en_US.utf8) preventing verification","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"tbl","mismatch_info":"PRIMARY KEY has a string field id has a different collation (pg=C, crdb=en_US.utf8) preventing verification","message":"mismatching table definition"}
 
 exec source
 DROP TABLE tbl;
@@ -34,4 +34,4 @@ CREATE TABLE tbl (
 verify
 ----
 {"level":"info","message":"starting verify on public.tbl, shard 1/1"}
-{"level":"info","message":"finished row verification on public.tbl (shard 1/1): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"tbl","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.tbl (shard 1/1)"}

--- a/verify/testdata/datadriven/pg/database_mismatch.ddt
+++ b/verify/testdata/datadriven/pg/database_mismatch.ddt
@@ -16,7 +16,7 @@ CREATE TABLE non_truth_table (id INT4 PRIMARY KEY)
 
 verify
 ----
-{"level":"warn","table_schema":"public","table_name":"truth_table","message":"missing table detected"}
-{"level":"warn","table_schema":"public","table_name":"non_truth_table","message":"extraneous table detected"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"truth_table","message":"missing table detected"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"non_truth_table","message":"extraneous table detected"}
 {"level":"info","message":"starting verify on public.in_both, shard 1/1"}
-{"level":"info","message":"finished row verification on public.in_both (shard 1/1): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"in_both","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.in_both (shard 1/1)"}

--- a/verify/testdata/datadriven/pg/row_mismatch.ddt
+++ b/verify/testdata/datadriven/pg/row_mismatch.ddt
@@ -42,18 +42,18 @@ SELECT id FROM generate_series(1, 100) AS t(id)
 verify
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/1): truth rows seen: 100, success: 100, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":100,"num_success":100,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 verify splits=4
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/4, range: [<beginning> - 25)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/4): truth rows seen: 24, success: 24, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/4, range: [25 - 49)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 2/4): truth rows seen: 24, success: 24, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/4, range: [49 - 73)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 3/4): truth rows seen: 24, success: 24, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 4/4, range: [73 - <end>]"}
-{"level":"info","message":"finished row verification on public.test_table (shard 4/4): truth rows seen: 28, success: 28, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":28,"num_success":28,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 4/4)"}
 
 exec all
 DROP TABLE test_table
@@ -100,12 +100,12 @@ INSERT INTO common_table VALUES
 verify
 ----
 {"level":"info","message":"starting verify on public.common_table, shard 1/1"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["50"],"message":"extraneous row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["125"],"message":"missing row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
-{"level":"info","message":"finished row verification on public.common_table (shard 1/1): truth rows seen: 6, success: 3, missing: 2, mismatch: 1, extraneous: 2, live_retry: 0"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["50"],"message":"extraneous row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["125"],"message":"missing row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":6,"num_success":3,"num_missing":2,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"message":"finished row verification on public.common_table (shard 1/1)"}
 
 # Verify with extraneous rows on source of truth.
 exec source
@@ -117,13 +117,13 @@ INSERT INTO common_table VALUES
 verify
 ----
 {"level":"info","message":"starting verify on public.common_table, shard 1/1"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["50"],"message":"extraneous row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["125"],"message":"missing row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
-{"level":"warn","table_schema":"public","table_name":"common_table","primary_key":["400"],"message":"missing row"}
-{"level":"info","message":"finished row verification on public.common_table (shard 1/1): truth rows seen: 7, success: 3, missing: 3, mismatch: 1, extraneous: 2, live_retry: 0"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["50"],"message":"extraneous row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["125"],"message":"missing row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["400"],"message":"missing row"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":7,"num_success":3,"num_missing":3,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"message":"finished row verification on public.common_table (shard 1/1)"}
 
 exec all
 DROP TABLE common_table
@@ -158,11 +158,11 @@ INSERT INTO table_misaligned_columns VALUES
 
 verify
 ----
-{"level":"warn","table_schema":"public","table_name":"table_misaligned_columns","mismatch_info":"extraneous column not_common_b found","message":"mismatching table definition"}
-{"level":"warn","table_schema":"public","table_name":"table_misaligned_columns","mismatch_info":"missing column not_common_a","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"table_misaligned_columns","mismatch_info":"extraneous column not_common_b found","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"table_misaligned_columns","mismatch_info":"missing column not_common_a","message":"mismatching table definition"}
 {"level":"info","message":"starting verify on public.table_misaligned_columns, shard 1/1"}
-{"level":"warn","table_schema":"public","table_name":"table_misaligned_columns","source_values":{"a":"3"},"target_values":{"a":"4"},"primary_key":["2"],"message":"mismatching row value"}
-{"level":"info","message":"finished row verification on public.table_misaligned_columns (shard 1/1): truth rows seen: 2, success: 1, missing: 0, mismatch: 1, extraneous: 0, live_retry: 0"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"table_misaligned_columns","source_values":{"a":"3"},"target_values":{"a":"4"},"primary_key":["2"],"message":"mismatching row value"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"table_misaligned_columns","num_truth_rows":2,"num_success":1,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.table_misaligned_columns (shard 1/1)"}
 
 exec all
 DROP TABLE table_misaligned_columns
@@ -198,5 +198,5 @@ INSERT INTO comparable_type VALUES
 verify
 ----
 {"level":"info","message":"starting verify on public.comparable_type, shard 1/1"}
-{"level":"warn","table_schema":"public","table_name":"comparable_type","source_values":{"j":"[\"mismatch\"]"},"target_values":{"j":"[\"big mismatch\"]"},"primary_key":["3"],"message":"mismatching row value"}
-{"level":"info","message":"finished row verification on public.comparable_type (shard 1/1): truth rows seen: 2, success: 1, missing: 0, mismatch: 1, extraneous: 0, live_retry: 0"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"comparable_type","source_values":{"j":"[\"mismatch\"]"},"target_values":{"j":"[\"big mismatch\"]"},"primary_key":["3"],"message":"mismatching row value"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"comparable_type","num_truth_rows":2,"num_success":1,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.comparable_type (shard 1/1)"}

--- a/verify/testdata/datadriven/pg/shard_table.ddt
+++ b/verify/testdata/datadriven/pg/shard_table.ddt
@@ -10,7 +10,7 @@ verify splits=4
 ----
 {"level":"info","message":"unable to identify a split for primary key public.test_table, defaulting to a full scan"}
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/1): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 exec all
 INSERT INTO test_table VALUES (1)
@@ -22,7 +22,7 @@ verify splits=4
 ----
 {"level":"info","message":"unable to identify a split for primary key public.test_table, defaulting to a full scan"}
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/1): truth rows seen: 1, success: 1, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 # 2 rows table can be split, but ranges may be jank.
 
@@ -35,13 +35,13 @@ INSERT INTO test_table VALUES (2)
 verify splits=4
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/4, range: [<beginning> - 1)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/4): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/4, range: [1 - 1)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 2/4): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/4, range: [1 - 1)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 3/4): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 4/4, range: [1 - <end>]"}
-{"level":"info","message":"finished row verification on public.test_table (shard 4/4): truth rows seen: 2, success: 2, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":2,"num_success":2,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 4/4)"}
 
 # UUIDs
 exec all
@@ -57,13 +57,13 @@ INSERT INTO test_table VALUES
 verify splits=4
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/4, range: [<beginning> - '3d15fb6c-2682-4991-0000-000000000000')"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/4): truth rows seen: 1, success: 1, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/4, range: ['3d15fb6c-2682-4991-0000-000000000000' - '59cbf92e-d230-4b9f-0000-000000000000')"}
-{"level":"info","message":"finished row verification on public.test_table (shard 2/4): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/4, range: ['59cbf92e-d230-4b9f-0000-000000000000' - '7681f6f1-7dde-4dad-0000-000000000000')"}
-{"level":"info","message":"finished row verification on public.test_table (shard 3/4): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 4/4, range: ['7681f6f1-7dde-4dad-0000-000000000000' - <end>]"}
-{"level":"info","message":"finished row verification on public.test_table (shard 4/4): truth rows seen: 1, success: 1, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 4/4)"}
 
 # Floats
 exec all
@@ -79,13 +79,13 @@ INSERT INTO test_table VALUES
 verify splits=4
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/4, range: [<beginning> - -1.446650225e+07)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/4): truth rows seen: 1, success: 1, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/4, range: [-1.446650225e+07 - -8.9335605e+06)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 2/4): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/4, range: [-8.9335605e+06 - -3.40061875e+06)"}
-{"level":"info","message":"finished row verification on public.test_table (shard 3/4): truth rows seen: 0, success: 0, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 4/4, range: [-3.40061875e+06 - <end>]"}
-{"level":"info","message":"finished row verification on public.test_table (shard 4/4): truth rows seen: 1, success: 1, missing: 0, mismatch: 0, extraneous: 0, live_retry: 0"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 4/4)"}
 
 exec all
 INSERT INTO test_table VALUES
@@ -98,5 +98,5 @@ verify splits=4
 ----
 {"level":"info","message":"unable to identify a split for primary key public.test_table, defaulting to a full scan"}
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"warn","table_schema":"public","table_name":"test_table","primary_key":["(-1.9999444e+07)"],"message":"extraneous row"}
-{"level":"info","message":"finished row verification on public.test_table (shard 1/1): truth rows seen: 3, success: 3, missing: 0, mismatch: 0, extraneous: 1, live_retry: 0"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"test_table","primary_key":["(-1.9999444e+07)"],"message":"extraneous row"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_missing":0,"num_mismatch":0,"num_extraneous":1,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}

--- a/verify/testdata/datadriven/pg/table_mismatch.ddt
+++ b/verify/testdata/datadriven/pg/table_mismatch.ddt
@@ -12,7 +12,7 @@ CREATE TABLE t (id INT4 PRIMARY KEY)
 
 verify
 ----
-{"level":"warn","table_schema":"public","table_name":"t","mismatch_info":"missing a PRIMARY KEY - results cannot be compared","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"t","mismatch_info":"missing a PRIMARY KEY - results cannot be compared","message":"mismatching table definition"}
 
 exec all
 DROP TABLE t
@@ -51,10 +51,10 @@ CREATE TABLE different_pk_type (
 
 verify
 ----
-{"level":"warn","table_schema":"public","table_name":"different_pk_type","mismatch_info":"column type mismatch on id: int8 vs float8","message":"mismatching table definition"}
-{"level":"warn","table_schema":"public","table_name":"different_pk_type","mismatch_info":"PRIMARY KEY does not match source of truth (columns and types must match)","message":"mismatching table definition"}
-{"level":"warn","table_schema":"public","table_name":"t","mismatch_info":"extraneous column mismatching_pk found","message":"mismatching table definition"}
-{"level":"warn","table_schema":"public","table_name":"t","mismatch_info":"extraneous column extra_col found","message":"mismatching table definition"}
-{"level":"warn","table_schema":"public","table_name":"t","mismatch_info":"column type mismatch on mismatching_type: int4 vs text","message":"mismatching table definition"}
-{"level":"warn","table_schema":"public","table_name":"t","mismatch_info":"missing column missing_in_lie_col","message":"mismatching table definition"}
-{"level":"warn","table_schema":"public","table_name":"t","mismatch_info":"PRIMARY KEY does not match source of truth (columns and types must match)","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"different_pk_type","mismatch_info":"column type mismatch on id: int8 vs float8","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"different_pk_type","mismatch_info":"PRIMARY KEY does not match source of truth (columns and types must match)","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"t","mismatch_info":"extraneous column mismatching_pk found","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"t","mismatch_info":"extraneous column extra_col found","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"t","mismatch_info":"column type mismatch on mismatching_type: int4 vs text","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"t","mismatch_info":"missing column missing_in_lie_col","message":"mismatching table definition"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"t","mismatch_info":"PRIMARY KEY does not match source of truth (columns and types must match)","message":"mismatching table definition"}


### PR DESCRIPTION
**Change 1**
Made the summary stats report the stats in the log as individual fields in JSON so that they can more easily be filtered and extracted. Previously, this would require regex extraction, but now can be indexed directly.

Release Note: Changed the output for the running summary statistics so that they are now more easily indexable by log processing tools. Previously, it was more human readable, but fields were not indexable easily out of the box. Now, there is a balance between readability and downstream processing.

**Change 2**
verify: updated reporting to use data and summary loggers in correct places
Verify centralizes logging in a LogReporter struct. Currently, they all log to the same task logger, but the change here is to get the appropriate loggers and annotate the lo gs as they come out.

Updated the logging messages to snake case types so that it's easier to process downstream for log processing tools without regexes.

Release Note: Added logging annotations for data level errors / information and summary status logs. In this context, summary logs are ones that are reported about the overall functioning of the job (i.e. 10000 truth rows seen, 5000 mismatches, etc.). The data ones report the exact issues that surfaced during the verify process. These can be filtered so that exact tables + rows can be triaged in one place.

Tasks
- [x] Fix tests