### PR TITLE
verify: support TINYINT to BOOL  mapping

### DIFF
--- a/docker/cockroach-init/cockroach-init.sql
+++ b/docker/cockroach-init/cockroach-init.sql
@@ -5,6 +5,7 @@ CREATE TABLE employees (
 	created_at TIMESTAMPTZ,
 	updated_at DATE,
 	is_hired BOOL,
+	age INT2,
 	salary DECIMAL(8,2),
 	bonus FLOAT4
 );

--- a/docker/mysql-init/mysql-init.sql
+++ b/docker/mysql-init/mysql-init.sql
@@ -2,7 +2,7 @@ CREATE DATABASE molt;
 use molt;
 CREATE TABLE employees (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    unique_id BINARY(16),
+    unique_id VARCHAR(100),
     name VARCHAR(50),
     created_at DATETIME,
     updated_at DATE,
@@ -23,7 +23,7 @@ BEGIN
     WHILE i <= 200000 DO
         INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, age, salary, bonus)
         VALUES (
-            UNHEX(REPLACE('550e8400-e29b-41d4-a716-446655440000', '-', '')),
+            '550e8400-e29b-41d4-a716-446655440000',
             CONCAT('Employee_', i),
             '2023-11-03 09:00:00',
             '2023-11-03',

--- a/docker/mysql-init/mysql-init.sql
+++ b/docker/mysql-init/mysql-init.sql
@@ -7,6 +7,7 @@ CREATE TABLE employees (
     created_at DATETIME,
     updated_at DATE,
     is_hired TINYINT(1),
+    age TINYINT(2),
     salary DECIMAL(8, 2),
     bonus FLOAT
 );
@@ -20,13 +21,14 @@ BEGIN
     START TRANSACTION;
 
     WHILE i <= 200000 DO
-        INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, salary, bonus)
+        INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, age, salary, bonus)
         VALUES (
             UNHEX(REPLACE('550e8400-e29b-41d4-a716-446655440000', '-', '')),
             CONCAT('Employee_', i),
             '2023-11-03 09:00:00',
             '2023-11-03',
             1,
+            24,
             5000.00,
             100.25
         );

--- a/docker/pg-init/pg-init.sql
+++ b/docker/pg-init/pg-init.sql
@@ -8,6 +8,7 @@ CREATE TABLE employees (
     created_at TIMESTAMPTZ,
     updated_at DATE,
     is_hired BOOLEAN,
+    age SMALLINT,
     salary NUMERIC(8, 2),
     bonus REAL
 );
@@ -18,13 +19,14 @@ DECLARE
 BEGIN
     i := 1;
     WHILE i <= 200000 LOOP
-        INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, salary, bonus)
+        INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, age, salary, bonus)
         VALUES (
             ('550e8400-e29b-41d4-a716-446655440000'::uuid),
             'Employee_' || i,
             '2023-11-03 09:00:00'::timestamp,
             '2023-11-03'::date,
             true,
+            24,
             5000.00,
             100.25
         );

--- a/verify/tableverify/tableverify.go
+++ b/verify/tableverify/tableverify.go
@@ -302,5 +302,9 @@ func allowableTypes(a oid.Oid, b oid.Oid) bool {
 	if a == oid.T_varchar && b == oid.T_uuid {
 		return true
 	}
+	if a == oid.T_int2 && b == oid.T_bool {
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
Previously, there were many warnings about mismatching column definitions because there is not a direct translation from a MySQL TINYINT(1), which is used for booleans, and the CRDB BOOL value. This change aims to add support for this in comparable types.

Release Note: TINYINT(1) in MySQL now maps to BOOL types in Cockroach, which resolves a mismatching table definition error.

TODO:
- [ ] Investigate panic when comparing types that are different
- [ ] Add unit/integration tests

**Fetch Testing**
```
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . fetch \    
  --source 'mysql://root:password@localhost/molt' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --log-file fetch.log --direct-copy
{"level":"info","time":"2023-12-12T15:15:13-08:00","message":"default compression to none"}
{"level":"info","time":"2023-12-12T15:15:13-08:00","message":"checking database details"}
{"level":"info","source_table":"public.employees","target_table":"public.employees","time":"2023-12-12T15:15:13-08:00","message":"found matching table"}
{"level":"info","time":"2023-12-12T15:15:13-08:00","message":"verifying common tables"}
{"level":"info","time":"2023-12-12T15:15:13-08:00","message":"establishing snapshot"}
{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"5e2fed98-d333-11ed-bc69-b9ae403342b1:1-172","time":"2023-12-12T15:15:13-08:00","message":"starting fetch"}
{"level":"warn","table":"public.employees","reason":"column type mismatch on unique_id: bytea vs uuid","time":"2023-12-12T15:15:13-08:00","message":"not migrating column {public employees} as it mismatches"}
{"level":"info","table":"public.employees","time":"2023-12-12T15:15:13-08:00","message":"data extraction phase starting"}
{"level":"info","table":"public.employees","type":"data","num_rows":100000,"time":"2023-12-12T15:15:14-08:00","message":"row import status"}
{"level":"info","table":"public.employees","type":"data","num_rows":200000,"time":"2023-12-12T15:15:15-08:00","message":"row import status"}
{"level":"info","table":"public.employees","type":"summary","num_rows":200000,"export_duration_ms":2720.051875,"export_duration":"000h 00m 02s","time":"2023-12-12T15:15:15-08:00","message":"data extraction from source complete"}
{"level":"info","type":"summary","num_tables":1,"tables":["public.employees"],"cdc_cursor":"5e2fed98-d333-11ed-bc69-b9ae403342b1:1-172","time":"2023-12-12T15:15:15-08:00","message":"fetch complete"}
```

We can see that it shows the relevant rows:
```
  id | unique_id |    name    |       created_at       | updated_at | is_hired | age | salary  | bonus
-----+-----------+------------+------------------------+------------+----------+-----+---------+---------
   1 | NULL      | Employee_1 | 2023-11-03 09:00:00+00 | 2023-11-03 |   true   |  24 | 5000.00 | 100.25
   2 | NULL      | Employee_2 | 2023-11-03 09:00:00+00 | 2023-11-03 |   true   |  24 | 5000.00 | 100.25
   3 | NULL      | Employee_3 | 2023-11-03 09:00:00+00 | 2023-11-03 |   true   |  24 | 5000.00 | 100.25
   4 | NULL      | Employee_4 | 2023-11-03 09:00:00+00 | 2023-11-03 |   true   |  24 | 5000.00 | 100.25
   5 | NULL      | Employee_5 | 2023-11-03 09:00:00+00 | 2023-11-03 |   true   |  24 | 5000.00 | 100.25
```

**Verify Testing**
Before
```
```

After
```
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . verify \
  --source 'mysql://root:password@localhost/molt' \     
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --log-file verify.log
{"level":"info","time":"2023-12-12T15:16:50-08:00","message":"verification in progress"}
{"level":"warn","type":"data","table_schema":"public","table_name":"employees","mismatch_info":"column type mismatch on unique_id: bytea vs uuid","time":"2023-12-12T15:16:50-08:00","message":"mismatching table definition"}
{"level":"info","time":"2023-12-12T15:16:50-08:00","message":"starting verify on public.employees, shard 1/1"}
{"level":"info","time":"2023-12-12T15:16:50-08:00","message":"verification complete"}
panic: unsupported comparison: bool to int
```
