### PR TITLE
verify: made a helper to check dependency of flags on a root flag

### DIFF
--- a/cmd/internal/cmdutil/flags.go
+++ b/cmd/internal/cmdutil/flags.go
@@ -1,0 +1,28 @@
+package cmdutil
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+func CheckFlagDependency(cmd *cobra.Command, dependencyFlag string, dependentFlags []string) error {
+	// Merge persistent flags.
+	cmd.Flags().AddFlagSet(cmd.PersistentFlags())
+	dependency := cmd.Flags().Lookup(dependencyFlag)
+	if dependency == nil {
+		return errors.Newf(`Flag "%s" not found`, dependencyFlag)
+	}
+
+	for _, v := range dependentFlags {
+		dependent := cmd.Flags().Lookup(v)
+		if dependent == nil {
+			return errors.Newf(`Flag "%s" not found`, v)
+		}
+
+		if !dependency.Changed && dependent.Changed {
+			return errors.Newf(`Flag "%s" set without explicitly setting dependency "%s"`, v, dependencyFlag)
+		}
+	}
+
+	return nil
+}

--- a/cmd/internal/cmdutil/flags_test.go
+++ b/cmd/internal/cmdutil/flags_test.go
@@ -1,0 +1,96 @@
+package cmdutil
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckFlagDependency(t *testing.T) {
+	cmd := &cobra.Command{}
+	// Mix in persistent and no persistent flags to properly test for mixed case.
+	cmd.PersistentFlags().Bool("dependency", false, "")
+	cmd.Flags().Bool("updated-dependency", false, "")
+	require.NoError(t, cmd.Flags().Set("updated-dependency", "true"))
+
+	cmd.Flags().Bool("not-updated-dependent", false, "")
+	cmd.PersistentFlags().Bool("updated-dependent", false, "")
+	require.NoError(t, cmd.PersistentFlags().Set("updated-dependent", "true"))
+
+	type args struct {
+		cmd            *cobra.Command
+		dependencyFlag string
+		dependentFlags []string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		expectedErr error
+	}{
+		{
+			name: "dependency flag does not exist",
+			args: args{
+				cmd:            cmd,
+				dependencyFlag: "non-existent",
+			},
+			expectedErr: errors.New(`Flag "non-existent" not found`),
+		},
+		{
+			name: "dependent flags do not exist",
+			args: args{
+				cmd:            cmd,
+				dependencyFlag: "dependency",
+				dependentFlags: []string{"missing-dependent-flag"},
+			},
+			expectedErr: errors.New(`Flag "missing-dependent-flag" not found`),
+		},
+		{
+			name: "neither dependent nor dependency flag set by user",
+			args: args{
+				cmd:            cmd,
+				dependencyFlag: "dependency",
+				dependentFlags: []string{"not-updated-dependent"},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "neither dependent nor dependency flag set by user",
+			args: args{
+				cmd:            cmd,
+				dependencyFlag: "dependency",
+				dependentFlags: []string{"not-updated-dependent"},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "both dependent and dependency flag set by user",
+			args: args{
+				cmd:            cmd,
+				dependencyFlag: "updated-dependency",
+				dependentFlags: []string{"updated-dependent"},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "dependent flag not set but dependency flag set by user",
+			args: args{
+				cmd:            cmd,
+				dependencyFlag: "dependency",
+				dependentFlags: []string{"updated-dependent"},
+			},
+			expectedErr: errors.New(`Flag "updated-dependent" set without explicitly setting dependency "dependency"`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualErr := CheckFlagDependency(tt.args.cmd, tt.args.dependencyFlag, tt.args.dependentFlags)
+			if tt.expectedErr != nil {
+				require.EqualError(t, tt.expectedErr, actualErr.Error())
+			} else {
+				require.Nil(t, actualErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, flags were grouped together by the MarkFlagRequiredTogether method that Cobra supplies. This ends up having the downside that all flags marked together must be set, which makes for a worse UX because people need to supply more flags instead of relying on sane defaults.

The change here is to introduce a concept of dependencies so that a flag can mark a one-directional dependency to another flag so that if a child is set without the parent dependency, it will error out. But if the parent is set, the child doesn't necessarily need to be set.

Release Note: Release Note: Marked the "live" and "continuous" flags as dependencies for other sub-configuration flags. Disregard the MarkFlagRequiredTogether note from above. This provides a clearer user experience so that if a flag is set without its dependency, molt will let you know which dependency flag is not correctly set.

Methodology was informed by this: https://github.com/spf13/cobra/issues/23#issuecomment-591680477

**Testing**
```
# Child set without parent
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . verify \
  --source 'mysql://root:password@localhost/molt' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --continuous-pause-between-runs 1s
Error: Flag "continuous-pause-between-runs" set without dependency "continuous"

(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . verify \
  --source 'mysql://root:password@localhost/molt' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --live-runs-per-second 2
Error: Flag "live-runs-per-second" set without dependency "live"

(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . verify \
  --source 'mysql://root:password@localhost/molt' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --live-max-batch-size 2 
Error: Flag "live-max-batch-size" set without dependency "live"

(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . verify \
  --source 'mysql://root:password@localhost/molt' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --live-flush-interval 1h
Error: Flag "live-flush-interval" set without dependency "live"

# Parent can be set without children (uses sane defaults)
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . verify \
  --source 'mysql://root:password@localhost/molt' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --continuous
{"level":"info","time":"2023-12-12T18:36:07-08:00","message":"verification in progress"}
{"level":"warn","type":"data","table_schema":"public","table_name":"employees","mismatch_info":"column type mismatch on unique_id: bytea vs uuid","time":"2023-12-12T18:36:07-08:00","message":"mismatching table definition"}
{"level":"warn","type":"data","table_schema":"public","table_name":"employees","mismatch_info":"column type mismatch on is_hired: int2 vs bool","time":"2023-12-12T18:36:07-08:00","message":"mismatching table definition"}

(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . verify \
  --source 'mysql://root:password@localhost/molt' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --live      
{"level":"info","time":"2023-12-12T18:36:46-08:00","message":"verification in progress"}
{"level":"warn","type":"data","table_schema":"public","table_name":"employees","mismatch_info":"column type mismatch on unique_id: bytea vs uuid","time":"2023-12-12T18:36:47-08:00","message":"mismatching table definition"}
```