### PR TITLE
docker: added in prometheus and grafana containers to view MOLT metrics

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,3 +37,31 @@ services:
       - "26257:26257"
     volumes:
       - ./cockroach-init:/docker-entrypoint-initdb.d
+
+  prometheus:
+    image: prom/prometheus:latest
+    restart: always
+    working_dir: /prometheus
+    command: --config.file=prometheus.yml
+    ports:
+      - "9090:9090"
+    expose:
+      - "9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:latest
+    working_dir: /grafana
+    depends_on:
+      - prometheus
+    ports:
+      - 3000:3000
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      # TODO (rluu): put this in when we have a dashboard template.
+      #  - ./grafana/dashboard.json:/grafana/dashboard/dashboard.json
+      - ./grafana/dashboard.yaml:/etc/grafana/provisioning/dashboards/main.yaml
+      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/prometheus_ds.yml

--- a/docker/grafana/dashboard.yaml
+++ b/docker/grafana/dashboard.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "Dashboard provider"
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /grafana/dashboard/dashboard.json
+      foldersFromFilesStructure: true

--- a/docker/grafana/datasource.yml
+++ b/docker/grafana/datasource.yml
@@ -1,0 +1,6 @@
+datasources:
+  - name: prometheus
+    access: proxy
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    metrics_path: '/metrics'
+    scrape_interval: 5s
+    static_configs:
+      # Using host.docker.internal because MOLT verify/fetch is run on the host.
+      # In the case that we run in a Docker container, we can update the host reference here.
+      - targets: ['host.docker.internal:3030']


### PR DESCRIPTION
Added in the scaffolding for containers to collect prometheus metrics and view them with Grafana. Added in several TODOs for updating the dashboard, which will be addressed in a future PR.

Resolves: CC-26355
Release Note: None

**Screenshots**
<img width="1023" alt="image" src="https://github.com/cockroachdb/molt/assets/23587815/7320c906-3116-4d55-8388-6fafb3826faa">

<img width="1482" alt="image" src="https://github.com/cockroachdb/molt/assets/23587815/ae119507-99fe-4598-8610-4860dac49b19">
