### PR TITLE
verify: switched usage from Compare to CompareError to resolve panic

### DIFF
--- a/docker/cockroach-init/cockroach-init.sql
+++ b/docker/cockroach-init/cockroach-init.sql
@@ -5,6 +5,7 @@ CREATE TABLE employees (
 	created_at TIMESTAMPTZ,
 	updated_at DATE,
 	is_hired BOOL,
+	age INT2,
 	salary DECIMAL(8,2),
 	bonus FLOAT4
 );

--- a/docker/mysql-init/mysql-init.sql
+++ b/docker/mysql-init/mysql-init.sql
@@ -2,11 +2,12 @@ CREATE DATABASE molt;
 use molt;
 CREATE TABLE employees (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    unique_id BINARY(16),
+    unique_id VARCHAR(100),
     name VARCHAR(50),
     created_at DATETIME,
     updated_at DATE,
     is_hired TINYINT(1),
+    age TINYINT(2),
     salary DECIMAL(8, 2),
     bonus FLOAT
 );
@@ -20,13 +21,14 @@ BEGIN
     START TRANSACTION;
 
     WHILE i <= 200000 DO
-        INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, salary, bonus)
+        INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, age, salary, bonus)
         VALUES (
-            UNHEX(REPLACE('550e8400-e29b-41d4-a716-446655440000', '-', '')),
+            '550e8400-e29b-41d4-a716-446655440000',
             CONCAT('Employee_', i),
             '2023-11-03 09:00:00',
             '2023-11-03',
             1,
+            24,
             5000.00,
             100.25
         );

--- a/docker/pg-init/pg-init.sql
+++ b/docker/pg-init/pg-init.sql
@@ -8,6 +8,7 @@ CREATE TABLE employees (
     created_at TIMESTAMPTZ,
     updated_at DATE,
     is_hired BOOLEAN,
+    age SMALLINT,
     salary NUMERIC(8, 2),
     bonus REAL
 );
@@ -18,13 +19,14 @@ DECLARE
 BEGIN
     i := 1;
     WHILE i <= 200000 LOOP
-        INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, salary, bonus)
+        INSERT INTO employees (unique_id, name, created_at, updated_at, is_hired, age, salary, bonus)
         VALUES (
             ('550e8400-e29b-41d4-a716-446655440000'::uuid),
             'Employee_' || i,
             '2023-11-03 09:00:00'::timestamp,
             '2023-11-03'::date,
             true,
+            24,
             5000.00,
             100.25
         );

--- a/verify/inconsistency/reporter.go
+++ b/verify/inconsistency/reporter.go
@@ -100,7 +100,7 @@ func (l LogReporter) Report(obj ReportableObject) {
 		}
 
 		joinedInfo := strings.Join(obj.Info, ";")
-		msg := fmt.Sprintf("mismatching column found - %s", joinedInfo)
+		msg := fmt.Sprintf("mismatching column(s) found - %s", joinedInfo)
 
 		dataLogger.Warn().
 			Str("table_schema", string(obj.Schema)).

--- a/verify/inconsistency/row.go
+++ b/verify/inconsistency/row.go
@@ -34,3 +34,15 @@ type MismatchingRow struct {
 	TruthVals          tree.Datums
 	TargetVals         tree.Datums
 }
+
+type MismatchingColumn struct {
+	dbtable.Name
+
+	PrimaryKeyColumns []tree.Name
+	PrimaryKeyValues  tree.Datums
+
+	MismatchingColumns []tree.Name
+	TruthVals          tree.Datums
+	TargetVals         tree.Datums
+	Info               []string
+}

--- a/verify/inconsistency/stats.go
+++ b/verify/inconsistency/stats.go
@@ -8,14 +8,16 @@ import (
 
 // RowStats includes all details about the total rows processed.
 type RowStats struct {
-	Schema        string
-	Table         string
-	NumVerified   int
-	NumSuccess    int
-	NumMissing    int
-	NumMismatch   int
-	NumExtraneous int
-	NumLiveRetry  int
+	Schema                string
+	Table                 string
+	NumVerified           int
+	NumSuccess            int
+	NumConditionalSuccess int
+	NumMissing            int
+	NumMismatch           int
+	NumColumnMismatch     int
+	NumExtraneous         int
+	NumLiveRetry          int
 }
 
 func (s *RowStats) String() string {
@@ -33,14 +35,20 @@ func (s *RowStats) String() string {
 // reportRunningSummary reports the number of total rows and errors seen
 // during the execution of verify.
 func reportRunningSummary(l zerolog.Logger, s RowStats, m string) {
+	if s.NumConditionalSuccess > 0 {
+		m = fmt.Sprintf("%s - please check all warnings and errors for column mismatches to determine success", m)
+	}
+
 	l.Info().
 		Str("table_schema", s.Schema).
 		Str("table_name", s.Table).
 		Int("num_truth_rows", s.NumVerified).
 		Int("num_success", s.NumSuccess).
+		Int("num_conditional_success", s.NumConditionalSuccess).
 		Int("num_missing", s.NumMissing).
 		Int("num_mismatch", s.NumMismatch).
 		Int("num_extraneous", s.NumExtraneous).
 		Int("num_live_retry", s.NumLiveRetry).
+		Int("num_column_mismatch", s.NumColumnMismatch).
 		Msg(m)
 }

--- a/verify/inconsistency/stats.go
+++ b/verify/inconsistency/stats.go
@@ -36,7 +36,7 @@ func (s *RowStats) String() string {
 // during the execution of verify.
 func reportRunningSummary(l zerolog.Logger, s RowStats, m string) {
 	if s.NumConditionalSuccess > 0 {
-		m = fmt.Sprintf("%s - please check all warnings and errors for column mismatches to determine success", m)
+		m = fmt.Sprintf("%s - please check all warnings and errors to determine whether column mismatches can be ignored", m)
 	}
 
 	l.Info().

--- a/verify/rowverify/live_reverifier.go
+++ b/verify/rowverify/live_reverifier.go
@@ -241,4 +241,10 @@ func (r *reverifyEventListener) OnMatch() {
 	r.BaseListener.OnMatch()
 }
 
+func (r *reverifyEventListener) OnColumnMismatchNoOtherIssues(
+	row inconsistency.MismatchingColumn, reportLog bool,
+) {
+	r.BaseListener.OnColumnMismatchNoOtherIssues(row, reportLog)
+}
+
 func (r *reverifyEventListener) OnRowScan() {}

--- a/verify/rowverify/live_reverifier_test.go
+++ b/verify/rowverify/live_reverifier_test.go
@@ -242,4 +242,9 @@ func (m *mockRowEventListener) OnMismatchingRow(row inconsistency.MismatchingRow
 
 func (m *mockRowEventListener) OnMatch() {}
 
+func (m *mockRowEventListener) OnColumnMismatchNoOtherIssues(
+	row inconsistency.MismatchingColumn, reportLog bool,
+) {
+}
+
 func (m *mockRowEventListener) OnRowScan() {}

--- a/verify/rowverify/row_event_listener.go
+++ b/verify/rowverify/row_event_listener.go
@@ -79,9 +79,9 @@ func (n *defaultRowEventListener) OnColumnMismatchNoOtherIssues(
 	// so we don't double count mismatching columns and reporting for mismatching columns.
 	if reportLog {
 		n.reporter.Report(row)
-		numMismatchingCols := float64(int(len(row.MismatchingColumns)))
-		rowStatusMetric.WithLabelValues("mismatching_column").Add(numMismatchingCols)
-		n.stats.NumColumnMismatch += len(row.MismatchingColumns)
+		numMismatchingCols := len(row.MismatchingColumns)
+		rowStatusMetric.WithLabelValues("mismatching_column").Add(float64(numMismatchingCols))
+		n.stats.NumColumnMismatch += numMismatchingCols
 	}
 	n.stats.NumConditionalSuccess++
 	rowStatusMetric.WithLabelValues("conditional_success").Inc()

--- a/verify/tableverify/tableverify.go
+++ b/verify/tableverify/tableverify.go
@@ -302,5 +302,8 @@ func allowableTypes(a oid.Oid, b oid.Oid) bool {
 	if a == oid.T_varchar && b == oid.T_uuid {
 		return true
 	}
+	if a == oid.T_int2 && b == oid.T_bool {
+		return true
+	}
 	return false
 }

--- a/verify/testdata/datadriven/mysql/casing.ddt
+++ b/verify/testdata/datadriven/mysql/casing.ddt
@@ -13,4 +13,4 @@ verify
 {"level":"warn","type":"data","table_schema":"public","table_name":"tbl","mismatch_info":"extraneous column xXx found","message":"mismatching table definition"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"tbl","mismatch_info":"missing column xxx","message":"mismatching table definition"}
 {"level":"info","message":"starting verify on public.Tbl, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"\"Tbl\"","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.Tbl (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"\"Tbl\"","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.Tbl (shard 1/1)"}

--- a/verify/testdata/datadriven/mysql/collation.ddt
+++ b/verify/testdata/datadriven/mysql/collation.ddt
@@ -34,4 +34,4 @@ CREATE TABLE tbl (
 verify
 ----
 {"level":"info","message":"starting verify on public.tbl, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"tbl","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.tbl (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"tbl","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.tbl (shard 1/1)"}

--- a/verify/testdata/datadriven/mysql/column_type_mismatch.ddt
+++ b/verify/testdata/datadriven/mysql/column_type_mismatch.ddt
@@ -1,0 +1,50 @@
+exec source
+CREATE TABLE test_table (
+    id INT4 PRIMARY KEY,
+    unique_id VARCHAR(100) DEFAULT '550e8400-e29b-41d4-a716-446655440000',
+    is_hired TINYINT(1) DEFAULT 1,
+    name VARCHAR(50) DEFAULT 'name',
+    age TINYINT(2) DEFAULT 24,
+    ts_table TIMESTAMP NOT NULL DEFAULT '2020-01-02 19:18:17',
+    dt_table DATETIME NOT NULL DEFAULT '2020-01-02 19:18:17'
+)
+----
+[mysql] 0 rows affected
+
+exec target
+CREATE TABLE test_table (
+    id INT8 PRIMARY KEY,
+    unique_id UUID DEFAULT '550e8400-e29b-41d4-a716-446655440000',
+    is_hired BOOL DEFAULT true,
+    name VARCHAR(50) DEFAULT 'name',
+    age INT2 DEFAULT 24,
+    ts_table TIMESTAMPTZ NOT NULL DEFAULT '2020-01-02 19:18:17',
+    dt_table TIMESTAMP NOT NULL DEFAULT '2020-01-02 19:18:17'
+)
+----
+[crdb] CREATE TABLE
+
+exec all
+INSERT INTO test_table (id) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+----
+[mysql] 10 rows affected
+[crdb] INSERT 0 10
+
+verify
+----
+{"level":"info","message":"starting verify on public.test_table, shard 1/1"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"test_table","source_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000","is_hired":"1"},"target_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000","is_hired":"true"},"primary_key":["1"],"message":"mismatching column(s) found - unique_id (unsupported comparison: uuid to string);is_hired (unsupported comparison: bool to int)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":10,"num_success":0,"num_conditional_success":10,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":2,"message":"finished row verification on public.test_table (shard 1/1) - please check all warnings and errors to determine whether column mismatches can be ignored"}
+
+verify splits=3
+----
+{"level":"info","message":"starting verify on public.test_table, shard 1/3, range: [<beginning> - 4)"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"test_table","source_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000","is_hired":"1"},"target_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000","is_hired":"true"},"primary_key":["1"],"message":"mismatching column(s) found - unique_id (unsupported comparison: uuid to string);is_hired (unsupported comparison: bool to int)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":0,"num_conditional_success":3,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":2,"message":"finished row verification on public.test_table (shard 1/3) - please check all warnings and errors to determine whether column mismatches can be ignored"}
+{"level":"info","message":"starting verify on public.test_table, shard 2/3, range: [4 - 7)"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"test_table","source_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000","is_hired":"1"},"target_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000","is_hired":"true"},"primary_key":["4"],"message":"mismatching column(s) found - unique_id (unsupported comparison: uuid to string);is_hired (unsupported comparison: bool to int)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":0,"num_conditional_success":3,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":2,"message":"finished row verification on public.test_table (shard 2/3) - please check all warnings and errors to determine whether column mismatches can be ignored"}
+{"level":"info","message":"starting verify on public.test_table, shard 3/3, range: [7 - <end>]"}
+{"level":"warn","type":"data","table_schema":"public","table_name":"test_table","source_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000","is_hired":"1"},"target_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000","is_hired":"true"},"primary_key":["7"],"message":"mismatching column(s) found - unique_id (unsupported comparison: uuid to string);is_hired (unsupported comparison: bool to int)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":4,"num_success":0,"num_conditional_success":4,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":2,"message":"finished row verification on public.test_table (shard 3/3) - please check all warnings and errors to determine whether column mismatches can be ignored"}

--- a/verify/testdata/datadriven/mysql/enum.ddt
+++ b/verify/testdata/datadriven/mysql/enum.ddt
@@ -27,4 +27,4 @@ verify
 ----
 {"level":"info","message":"starting verify on public.enum_table, shard 1/1"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"enum_table","source_values":{"s":"b"},"target_values":{"s":"c"},"primary_key":["2"],"message":"mismatching row value"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"enum_table","num_truth_rows":2,"num_success":1,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.enum_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"enum_table","num_truth_rows":2,"num_success":1,"num_conditional_success":0,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.enum_table (shard 1/1)"}

--- a/verify/testdata/datadriven/mysql/row_mismatch.ddt
+++ b/verify/testdata/datadriven/mysql/row_mismatch.ddt
@@ -29,7 +29,7 @@ INSERT INTO test_table (id) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), 
 verify
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":10,"num_success":10,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":10,"num_success":10,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 exec all
 DROP TABLE test_table
@@ -67,16 +67,16 @@ INSERT INTO test_table (id) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), 
 verify
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":10,"num_success":10,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":10,"num_success":10,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 verify splits=3
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/3, range: [<beginning> - 4)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/3)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/3)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/3, range: [4 - 7)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/3)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 2/3)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/3, range: [7 - <end>]"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":4,"num_success":4,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/3)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":4,"num_success":4,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 3/3)"}
 
 exec all
 DROP TABLE test_table
@@ -126,7 +126,7 @@ verify
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":6,"num_success":3,"num_missing":2,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"message":"finished row verification on public.common_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":6,"num_success":3,"num_conditional_success":0,"num_missing":2,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.common_table (shard 1/1)"}
 
 # Verify with extraneous rows on source of truth.
 exec source
@@ -144,7 +144,7 @@ verify
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["400"],"message":"missing row"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":7,"num_success":3,"num_missing":3,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"message":"finished row verification on public.common_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":7,"num_success":3,"num_conditional_success":0,"num_missing":3,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.common_table (shard 1/1)"}
 
 exec all
 DROP TABLE common_table

--- a/verify/testdata/datadriven/pg/collation.ddt
+++ b/verify/testdata/datadriven/pg/collation.ddt
@@ -34,4 +34,4 @@ CREATE TABLE tbl (
 verify
 ----
 {"level":"info","message":"starting verify on public.tbl, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"tbl","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.tbl (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"tbl","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.tbl (shard 1/1)"}

--- a/verify/testdata/datadriven/pg/database_mismatch.ddt
+++ b/verify/testdata/datadriven/pg/database_mismatch.ddt
@@ -19,4 +19,4 @@ verify
 {"level":"warn","type":"data","table_schema":"public","table_name":"truth_table","message":"missing table detected"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"non_truth_table","message":"extraneous table detected"}
 {"level":"info","message":"starting verify on public.in_both, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"in_both","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.in_both (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"in_both","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.in_both (shard 1/1)"}

--- a/verify/testdata/datadriven/pg/row_mismatch.ddt
+++ b/verify/testdata/datadriven/pg/row_mismatch.ddt
@@ -42,18 +42,18 @@ SELECT id FROM generate_series(1, 100) AS t(id)
 verify
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":100,"num_success":100,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":100,"num_success":100,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 verify splits=4
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/4, range: [<beginning> - 25)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/4, range: [25 - 49)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 2/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/4, range: [49 - 73)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":24,"num_success":24,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 3/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 4/4, range: [73 - <end>]"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":28,"num_success":28,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 4/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":28,"num_success":28,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 4/4)"}
 
 exec all
 DROP TABLE test_table
@@ -105,7 +105,7 @@ verify
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","source_values":{"str":"different value"},"target_values":{"str":"NULL"},"primary_key":["150"],"message":"mismatching row value"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":6,"num_success":3,"num_missing":2,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"message":"finished row verification on public.common_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":6,"num_success":3,"num_conditional_success":0,"num_missing":2,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.common_table (shard 1/1)"}
 
 # Verify with extraneous rows on source of truth.
 exec source
@@ -123,7 +123,7 @@ verify
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["250"],"message":"missing row"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["300"],"message":"extraneous row"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"common_table","primary_key":["400"],"message":"missing row"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":7,"num_success":3,"num_missing":3,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"message":"finished row verification on public.common_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"common_table","num_truth_rows":7,"num_success":3,"num_conditional_success":0,"num_missing":3,"num_mismatch":1,"num_extraneous":2,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.common_table (shard 1/1)"}
 
 exec all
 DROP TABLE common_table
@@ -162,7 +162,7 @@ verify
 {"level":"warn","type":"data","table_schema":"public","table_name":"table_misaligned_columns","mismatch_info":"missing column not_common_a","message":"mismatching table definition"}
 {"level":"info","message":"starting verify on public.table_misaligned_columns, shard 1/1"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"table_misaligned_columns","source_values":{"a":"3"},"target_values":{"a":"4"},"primary_key":["2"],"message":"mismatching row value"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"table_misaligned_columns","num_truth_rows":2,"num_success":1,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.table_misaligned_columns (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"table_misaligned_columns","num_truth_rows":2,"num_success":1,"num_conditional_success":0,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.table_misaligned_columns (shard 1/1)"}
 
 exec all
 DROP TABLE table_misaligned_columns
@@ -199,4 +199,4 @@ verify
 ----
 {"level":"info","message":"starting verify on public.comparable_type, shard 1/1"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"comparable_type","source_values":{"j":"[\"mismatch\"]"},"target_values":{"j":"[\"big mismatch\"]"},"primary_key":["3"],"message":"mismatching row value"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"comparable_type","num_truth_rows":2,"num_success":1,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.comparable_type (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"comparable_type","num_truth_rows":2,"num_success":1,"num_conditional_success":0,"num_missing":0,"num_mismatch":1,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.comparable_type (shard 1/1)"}

--- a/verify/testdata/datadriven/pg/shard_table.ddt
+++ b/verify/testdata/datadriven/pg/shard_table.ddt
@@ -10,7 +10,7 @@ verify splits=4
 ----
 {"level":"info","message":"unable to identify a split for primary key public.test_table, defaulting to a full scan"}
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 exec all
 INSERT INTO test_table VALUES (1)
@@ -22,7 +22,7 @@ verify splits=4
 ----
 {"level":"info","message":"unable to identify a split for primary key public.test_table, defaulting to a full scan"}
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/1)"}
 
 # 2 rows table can be split, but ranges may be jank.
 
@@ -35,13 +35,13 @@ INSERT INTO test_table VALUES (2)
 verify splits=4
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/4, range: [<beginning> - 1)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/4, range: [1 - 1)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 2/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/4, range: [1 - 1)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 3/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 4/4, range: [1 - <end>]"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":2,"num_success":2,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 4/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":2,"num_success":2,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 4/4)"}
 
 # UUIDs
 exec all
@@ -57,13 +57,13 @@ INSERT INTO test_table VALUES
 verify splits=4
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/4, range: [<beginning> - '3d15fb6c-2682-4991-0000-000000000000')"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/4, range: ['3d15fb6c-2682-4991-0000-000000000000' - '59cbf92e-d230-4b9f-0000-000000000000')"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 2/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/4, range: ['59cbf92e-d230-4b9f-0000-000000000000' - '7681f6f1-7dde-4dad-0000-000000000000')"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 3/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 4/4, range: ['7681f6f1-7dde-4dad-0000-000000000000' - <end>]"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 4/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 4/4)"}
 
 # Floats
 exec all
@@ -79,13 +79,13 @@ INSERT INTO test_table VALUES
 verify splits=4
 ----
 {"level":"info","message":"starting verify on public.test_table, shard 1/4, range: [<beginning> - -1.446650225e+07)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 2/4, range: [-1.446650225e+07 - -8.9335605e+06)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 2/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 2/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 3/4, range: [-8.9335605e+06 - -3.40061875e+06)"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 3/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 3/4)"}
 {"level":"info","message":"starting verify on public.test_table, shard 4/4, range: [-3.40061875e+06 - <end>]"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 4/4)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":1,"num_success":1,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 4/4)"}
 
 exec all
 INSERT INTO test_table VALUES
@@ -99,4 +99,4 @@ verify splits=4
 {"level":"info","message":"unable to identify a split for primary key public.test_table, defaulting to a full scan"}
 {"level":"info","message":"starting verify on public.test_table, shard 1/1"}
 {"level":"warn","type":"data","table_schema":"public","table_name":"test_table","primary_key":["(-1.9999444e+07)"],"message":"extraneous row"}
-{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_missing":0,"num_mismatch":0,"num_extraneous":1,"num_live_retry":0,"message":"finished row verification on public.test_table (shard 1/1)"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"test_table","num_truth_rows":3,"num_success":3,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":1,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.test_table (shard 1/1)"}


### PR DESCRIPTION
TLDR; we prevent panics and mark the row now as a mismatch if columns mismatch.

Previously, if a comparison between heterogeneous types occurred, verify would panic and stop execution. With this change to use CompareError instead of Compare, verify no longer panics, but rather records the error and reports it to the logging and also marks the row as mismatched, which semantically is correct because even if values are the same, they are different types.

@rafiss recommended converting usage from `Compare` to `CompareError` so that we can handle the error on our side and figure out what to do when it happens.

Release Note: None

**Tests**
Before
```
{"level":"info","time":"2023-12-13T13:12:25-08:00","message":"starting verify on public.employees, shard 1/1"}
panic: unsupported comparison: uuid to string

goroutine 48 [running]:
github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree.(*DUuid).Compare(0x140006a2380?, {0x102c33ab0?, 0x103d99ee0?}, {0x102c43200?, 0x140008d1c20?})
        /Users/ryanluu/go/pkg/mod/github.com/cockroachdb/cockroachdb-parser@v0.0.0-20230705064001-302c9ad52e1a/pkg/sql/sem/tree/datum.go:1722 +0x50
github.com/cockroachdb/molt/verify/rowverify.verifyRows({0x102c33670, 0x103d99ee0}, {{0x102c36c20, 0x140006a21c0}, {0x102c36c20, 0x140006a2380}}, {{{{0x101e48959, 0x6}, {0x1400085f440, 0x9}}, ...}, ...}, ...)
        /Users/ryanluu/go/src/github.com/cockroachdb/molt/verify/rowverify/rowverify.go:159 +0x6b4
github.com/cockroachdb/molt/verify/rowverify.VerifyRowsOnShard({_, _}, {{0x102c3c660, 0x140004d3e90}, {0x102c3c330, 0x140005b8d80}}, {{{{0x101e48959, 0x6}, {0x1400085f440, 0x9}}, ...}, ...}, ...)
        /Users/ryanluu/go/src/github.com/cockroachdb/molt/verify/rowverify/rowverify.go:83 +0x664
github.com/cockroachdb/molt/verify.verifyRowShard({_, _}, {{0x102c3c660, 0x140004e2840}, {0x102c3c330, 0x14000867b80}}, {_, _}, {{_, _}, ...}, ...)
        /Users/ryanluu/go/src/github.com/cockroachdb/molt/verify/verify.go:307 +0x234
github.com/cockroachdb/molt/verify.Verify.func1()
        /Users/ryanluu/go/src/github.com/cockroachdb/molt/verify/verify.go:252 +0x4dc
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/ryanluu/go/pkg/mod/golang.org/x/sync@v0.2.0/errgroup/errgroup.go:75 +0x58
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        /Users/ryanluu/go/pkg/mod/golang.org/x/sync@v0.2.0/errgroup/errgroup.go:72 +0x98
exit status 2
```

Now
```
{"level":"warn","type":"data","table_schema":"public","table_name":"employees","source_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000"},"target_values":{"unique_id":"550e8400-e29b-41d4-a716-446655440000"},"primary_key":["18250"],"time":"2023-12-13T13:11:18-08:00","message":"mismatching row value - unsupported comparison: uuid to string"}
{"level":"info","type":"summary","table_schema":"public","table_name":"employees","num_truth_rows":200000,"num_success":0,"num_missing":0,"num_mismatch":200000,"num_extraneous":0,"num_live_retry":0,"time":"2023-12-13T13:12:11-08:00","message":"finished row verification on public.employees (shard 1/1)"}
```