### PR TITLE
verify: added in high level metrics for verify and refactored into the verifymetrics package

### DIFF
--- a/fetch/csv_pipe.go
+++ b/fetch/csv_pipe.go
@@ -5,9 +5,8 @@ import (
 	"io"
 
 	"github.com/cockroachdb/molt/dbtable"
+	"github.com/cockroachdb/molt/fetch/fetchmetrics"
 	"github.com/cockroachdb/molt/moltlogger"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
 )
 
@@ -25,15 +24,6 @@ type csvPipe struct {
 	numRows   int
 	newWriter func() io.WriteCloser
 }
-
-var (
-	importedRows = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "molt",
-		Subsystem: "fetch",
-		Name:      "rows_imported",
-		Help:      "Number of rows that have been imported in",
-	}, []string{"table"})
-)
 
 func newCSVPipe(
 	in io.Reader,
@@ -54,7 +44,7 @@ func newCSVPipe(
 func (p *csvPipe) Pipe(tn dbtable.Name) error {
 	r := csv.NewReader(p.in)
 	r.ReuseRecord = true
-	m := importedRows.WithLabelValues(tn.SafeString())
+	m := fetchmetrics.ImportedRows.WithLabelValues(tn.SafeString())
 	dataLogger := moltlogger.GetDataLogger(p.logger)
 	for {
 		record, err := r.Read()

--- a/fetch/fetchmetrics/metrics.go
+++ b/fetch/fetchmetrics/metrics.go
@@ -1,0 +1,20 @@
+package fetchmetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	Namespace = "molt"
+	Subsystem = "fetch"
+)
+
+var (
+	ImportedRows = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "rows_imported",
+		Help:      "Number of rows that have been imported in.",
+	}, []string{"table"})
+)

--- a/verify/inconsistency/reporter.go
+++ b/verify/inconsistency/reporter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/molt/dbconn"
 	"github.com/cockroachdb/molt/moltlogger"
+	"github.com/cockroachdb/molt/verify/verifymetrics"
 	"github.com/rs/zerolog"
 )
 
@@ -179,6 +180,7 @@ func (l FixReporter) Report(obj ReportableObject) {
 				panic(err)
 			}
 		}
+		verifymetrics.NumRowFixups.WithLabelValues("mismatching").Inc()
 	case MissingRow:
 		l.Logger.Info().
 			Str("table_schema", string(obj.Schema)).
@@ -211,6 +213,7 @@ func (l FixReporter) Report(obj ReportableObject) {
 				panic(err)
 			}
 		}
+		verifymetrics.NumRowFixups.WithLabelValues("missing").Inc()
 	case ExtraneousRow:
 		l.Logger.Info().
 			Str("table_schema", string(obj.Schema)).
@@ -231,6 +234,7 @@ func (l FixReporter) Report(obj ReportableObject) {
 				panic(err)
 			}
 		}
+		verifymetrics.NumRowFixups.WithLabelValues("extraneous").Inc()
 	}
 }
 

--- a/verify/rowverify/live_retry_queue.go
+++ b/verify/rowverify/live_retry_queue.go
@@ -3,23 +3,7 @@ package rowverify
 import (
 	"container/heap"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-)
-
-var (
-	liveReverifierPrimaryKeys = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "molt",
-		Subsystem: "verify",
-		Name:      "live_primary_keys",
-		Help:      "Number of primary keys that are being reverified.",
-	})
-	liveReverifierBatches = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "molt",
-		Subsystem: "verify",
-		Name:      "live_batches",
-		Help:      "Number of batches that are in the queue to be reverified.",
-	})
+	"github.com/cockroachdb/molt/verify/verifymetrics"
 )
 
 // liveRetryQueue implements the heap interface.
@@ -51,8 +35,8 @@ func (rq liveRetryQueue) Swap(i, j int) {
 func (rq *liveRetryQueue) Push(x any) {
 	rq.items = append(rq.items, x.(*liveRetryItem))
 	rq.numPKs += len(x.(*liveRetryItem).PrimaryKeys)
-	liveReverifierPrimaryKeys.Set(float64(rq.numPKs))
-	liveReverifierBatches.Set(float64(len(rq.items)))
+	verifymetrics.LivePrimaryKeys.Set(float64(rq.numPKs))
+	verifymetrics.LiveBatches.Set(float64(len(rq.items)))
 }
 
 func (rq *liveRetryQueue) Pop() any {
@@ -61,7 +45,7 @@ func (rq *liveRetryQueue) Pop() any {
 	item := old[n-1]
 	rq.items = old[0 : n-1]
 	rq.numPKs -= len(item.PrimaryKeys)
-	liveReverifierPrimaryKeys.Set(float64(rq.numPKs))
-	liveReverifierBatches.Set(float64(len(rq.items)))
+	verifymetrics.LivePrimaryKeys.Set(float64(rq.numPKs))
+	verifymetrics.LiveBatches.Set(float64(len(rq.items)))
 	return item
 }

--- a/verify/verifymetrics/metrics.go
+++ b/verify/verifymetrics/metrics.go
@@ -1,0 +1,104 @@
+package verifymetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	Namespace = "molt"
+	Subsystem = "verify"
+)
+
+var (
+	// Overall task
+	NumShards = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "shards_running",
+		Help:      "Number of verification shards that are running.",
+	})
+	NumTablesProcessed = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "num_tables",
+		Help:      "Number of tables per category.",
+	}, []string{"category"})
+	NumRowFixups = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "num_row_fixups",
+		Help:      "Number of fixups per category.",
+	}, []string{"category"})
+	OverallDuration = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "duration_seconds",
+		Help:      "Duration (in seconds) for the verify run.",
+	})
+
+	// Reverifier
+	LivePrimaryKeys = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "live_primary_keys",
+		Help:      "Number of primary keys that are being reverified.",
+	})
+	LiveBatches = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "live_batches",
+		Help:      "Number of batches that are in the queue to be reverified.",
+	})
+	LiveRows = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "live_reverified_rows",
+		Help:      "Number of rows that require reverification by the live reverifier.",
+	})
+	LiveRemainingPKs = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "live_queued_pks",
+		Help:      "Number of rows that are queued by the live reverifier.",
+	})
+	LiveRemainingBatches = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "live_queued_batches",
+		Help:      "Number of batches of rows that require the live reverifier.",
+	})
+
+	// Row verification.
+	RowStatus = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "row_verification_status",
+		Help:      "Status of rows that have been verified.",
+	}, []string{"status"})
+	RowsRead = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "rows_read",
+		Help:      "Rate of rows that are being read from source database.",
+	})
+
+	rowStatusCategories = []string{"extraneous", "missing", "mismatching", "mismatching_column", "success", "conditional_success"}
+	tableCategories     = []string{"verified", "missing", "extraneous"}
+	fixupCategories     = []string{"mismatching", "missing", "extraneous"}
+)
+
+func init() {
+	// Initialize the label for the number of tables processed.
+	for _, t := range tableCategories {
+		NumTablesProcessed.WithLabelValues(t)
+	}
+
+	for _, f := range fixupCategories {
+		NumRowFixups.WithLabelValues(f)
+	}
+
+	for _, r := range rowStatusCategories {
+		RowStatus.WithLabelValues(r)
+	}
+}


### PR DESCRIPTION
Added in a new package responsible for centralizing high level metrics for verify. We now track more detailed types of metrics about the tables processed and their category: verified, missing, extraneous. Additionally, moved some high level metrics to this new package so that all metrics are colocated for other devs to review.

Resolves: CC-26355
Release Note: Added in new metrics for consumption in dashboards - molt_verify_num_tables (split up by category), molt_verify_duration_ms (to see how long a MOLT run took).


**Testing Results**
```
# HELP molt_verify_duration_ms Duration (in ms) for the verify run.
# TYPE molt_verify_duration_ms gauge
molt_verify_duration_ms 4760

molt_verify_num_tables{category="extraneous"} 0
molt_verify_num_tables{category="missing"} 1
molt_verify_num_tables{category="verified"} 1

molt_verify_num_row_fixups{category="extraneous"} 0
molt_verify_num_row_fixups{category="mismatching"} 0
molt_verify_num_row_fixups{category="missing"} 10992
```

**Existing Metrics (number of rows of each type**
```
molt_verify_row_verification_status{status="conditional_success"} 0
molt_verify_row_verification_status{status="extraneous"} 0
molt_verify_row_verification_status{status="mismatching"} 0
molt_verify_row_verification_status{status="mismatching_column"} 0
molt_verify_row_verification_status{status="missing"} 200000
molt_verify_row_verification_status{status="success"} 0
# HELP molt_verify_rows_read Rate of rows that are being read from source database.
# TYPE molt_verify_rows_read counter
molt_verify_rows_read 200000
```