### PR TITLE
fetchmetrics: added all metric types and metric initializers

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/molt/dbconn"
 	"github.com/cockroachdb/molt/fetch"
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
+	"github.com/cockroachdb/molt/fetch/fetchmetrics"
 	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag/v2"
@@ -96,7 +97,7 @@ func Command() *cobra.Command {
 			default:
 				return errors.AssertionFailedf("data source must be configured (--s3-bucket, --gcp-bucket, --direct-copy)")
 			}
-			return fetch.Fetch(
+			err = fetch.Fetch(
 				ctx,
 				cfg,
 				logger,
@@ -104,6 +105,12 @@ func Command() *cobra.Command {
 				src,
 				cmdutil.TableFilter(),
 			)
+
+			if err != nil {
+				fetchmetrics.NumTaskErrors.Inc()
+			}
+
+			return err
 		},
 	}
 

--- a/fetch/csv_pipe.go
+++ b/fetch/csv_pipe.go
@@ -44,7 +44,7 @@ func newCSVPipe(
 func (p *csvPipe) Pipe(tn dbtable.Name) error {
 	r := csv.NewReader(p.in)
 	r.ReuseRecord = true
-	m := fetchmetrics.ImportedRows.WithLabelValues(tn.SafeString())
+	m := fetchmetrics.ExportedRows.WithLabelValues(tn.SafeString())
 	dataLogger := moltlogger.GetDataLogger(p.logger)
 	for {
 		record, err := r.Read()
@@ -59,7 +59,10 @@ func (p *csvPipe) Pipe(tn dbtable.Name) error {
 		p.numRows++
 		m.Inc()
 		if p.numRows%100000 == 0 {
-			dataLogger.Info().Int("num_rows", p.numRows).Msgf("row import status")
+			dataLogger.Info().
+				Str("table", tn.SafeString()).
+				Int("num_rows", p.numRows).
+				Msgf("row import status")
 		}
 		for _, s := range record {
 			p.currSize += len(s) + 1

--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -16,6 +16,7 @@ type Store interface {
 }
 
 type Resource interface {
+	Key() (string, error)
 	ImportURL() (string, error)
 	MarkForCleanup(ctx context.Context) error
 	Reader(ctx context.Context) (io.ReadCloser, error)

--- a/fetch/datablobstorage/gcp.go
+++ b/fetch/datablobstorage/gcp.go
@@ -90,6 +90,10 @@ func (r *gcpResource) ImportURL() (string, error) {
 	), nil
 }
 
+func (r *gcpResource) Key() (string, error) {
+	return r.key, nil
+}
+
 func (r *gcpResource) Reader(ctx context.Context) (io.ReadCloser, error) {
 	return r.store.client.Bucket(r.store.bucket).Object(r.key).NewReader(ctx)
 }

--- a/fetch/datablobstorage/local.go
+++ b/fetch/datablobstorage/local.go
@@ -161,6 +161,14 @@ func (l *localResource) ImportURL() (string, error) {
 	return fmt.Sprintf("http://%s/%s", l.store.crdbAccessAddr, rel), nil
 }
 
+func (l *localResource) Key() (string, error) {
+	rel, err := filepath.Rel(l.store.basePath, l.path)
+	if err != nil {
+		return "", errors.Wrapf(err, "error finding relative path")
+	}
+	return rel, nil
+}
+
 func (l *localResource) MarkForCleanup(ctx context.Context) error {
 	l.store.logger.Debug().Msgf("removing %s", l.path)
 	return os.Remove(l.path)

--- a/fetch/datablobstorage/s3.go
+++ b/fetch/datablobstorage/s3.go
@@ -45,6 +45,10 @@ func (s *s3Resource) ImportURL() (string, error) {
 	), nil
 }
 
+func (s *s3Resource) Key() (string, error) {
+	return s.key, nil
+}
+
 func (s *s3Resource) MarkForCleanup(ctx context.Context) error {
 	s.store.batchDelete.Lock()
 	defer s.store.batchDelete.Unlock()

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -184,6 +184,9 @@ func fetchTable(
 	table tableverify.Result,
 ) error {
 	tableStartTime := time.Now()
+	// Initialize metrics for this table so we can calculate a rate later.
+	fetchmetrics.ExportedRows.WithLabelValues(table.SafeString())
+	fetchmetrics.ImportedRows.WithLabelValues(table.SafeString())
 
 	for _, col := range table.MismatchingTableDefinitions {
 		logger.Warn().
@@ -260,6 +263,7 @@ func fetchTable(
 				if err != nil {
 					return err
 				}
+				fetchmetrics.ImportedRows.WithLabelValues(table.SafeString()).Add(float64(e.NumRows))
 				importDuration = utils.MaybeFormatDurationForTest(cfg.TestOnly, r.EndTime.Sub(r.StartTime))
 			} else {
 				r, err := Copy(ctx, targetConn, logger, table.VerifiedTable, e.Resources)

--- a/fetch/fetchmetrics/metrics.go
+++ b/fetch/fetchmetrics/metrics.go
@@ -28,6 +28,12 @@ var (
 		Name:      "rows_imported",
 		Help:      "Number of rows that have been imported by table.",
 	}, []string{"table"})
+	ExportedRows = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "rows_exported",
+		Help:      "Number of rows that have been exported by table.",
+	}, []string{"table"})
 
 	// Data errors are ones relating to individual rows or files processed
 	// for the import or copy.

--- a/fetch/fetchmetrics/metrics.go
+++ b/fetch/fetchmetrics/metrics.go
@@ -10,11 +10,71 @@ const (
 	Subsystem = "fetch"
 )
 
+// Just a note that these metrics are most useful in reporting progress
+// for each table/schema combination. However, we do need to
+// be mindful that there could be cardinality explosion for metrics
+// if there are many table + schema combinations.
 var (
+	// Counts of entities in the fetch runs.
+	NumTablesProcessed = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "num_tables",
+		Help:      "Number of tables migrated.",
+	})
 	ImportedRows = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: Subsystem,
 		Name:      "rows_imported",
-		Help:      "Number of rows that have been imported in.",
+		Help:      "Number of rows that have been imported by table.",
 	}, []string{"table"})
+
+	// Data errors are ones relating to individual rows or files processed
+	// for the import or copy.
+	// TODO: still need to integrate data errors when we do exceptions logging.
+	NumDataErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "num_data_errors",
+		Help:      "Number of data level errors by table.",
+	}, []string{"table"})
+	NumTaskErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "num_task_errors",
+		Help:      "Number of task errors.",
+	})
+
+	// Progress and duration metrics.
+	CompletionPercentage = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "completion_percent",
+		Help:      "Completion percent by table.",
+	}, []string{"table"})
+
+	TableExportDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "table_export_duration_ms",
+		Help:      "Duration (in milliseconds) for a particular table's export",
+	}, []string{"table"})
+	TableImportDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "table_import_duration_ms",
+		Help:      "Duration (in milliseconds) for a particular table's import",
+	}, []string{"table"})
+	TableOverallDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "table_overall_duration_ms",
+		Help:      "Duration (in milliseconds) for a particular table's fetch.",
+	}, []string{"table"})
+	OverallDuration = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: Subsystem,
+		Name:      "overall_duration",
+		Help:      "Duration (in seconds) for the overall fetch",
+	})
 )

--- a/fetch/import_table.go
+++ b/fetch/import_table.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/molt/dbconn"
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
+	"github.com/cockroachdb/molt/fetch/fetchmetrics"
 	"github.com/cockroachdb/molt/fetch/internal/dataquery"
 	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/cockroachdb/molt/retry"
@@ -101,6 +102,7 @@ func reportImportTableProgress(
 			frac := p[0].FractionCompleted
 			if frac != 0.0 && prevVal != frac {
 				dataLogger.Info().Str("completion", fmt.Sprintf("%.2f%%", frac*100)).Msgf("progress")
+				fetchmetrics.CompletionPercentage.WithLabelValues(table.SafeString()).Set(frac * 100)
 			}
 
 			prevVal = p[0].FractionCompleted


### PR DESCRIPTION
Previously, we only tracked metrics for the number of imported rows. This change aims to add details about progress, durations, errors/exceptions encountered, and the number of tables involved. The metrics will be plumbed through the codebase and capture meaningful data that will allow folks to understand the performance and stability of the system.

Resolves: CC-26354
Release Note: None

Test Run Results:
```
# HELP molt_fetch_num_tables Number of tables migrated.
# TYPE molt_fetch_num_tables counter
molt_fetch_num_tables 1
# HELP molt_fetch_num_task_errors Number of task errors by schema and table.
# TYPE molt_fetch_num_task_errors counter
molt_fetch_num_task_errors 0
# HELP molt_fetch_overall_duration Duration (in seconds) for the overall fetch
# TYPE molt_fetch_overall_duration gauge
molt_fetch_overall_duration 5.274946125
# HELP molt_fetch_rows_imported Number of rows that have been imported by schema and table.
# TYPE molt_fetch_rows_imported counter
molt_fetch_rows_imported{schema="public",table="public.employees"} 200000
# HELP molt_fetch_table_export_duration_ms Duration (in milliseconds) for a particular table's export
# TYPE molt_fetch_table_export_duration_ms gauge
molt_fetch_table_export_duration_ms{schema="public",table="public.employees"} 1897
# HELP molt_fetch_table_import_duration_ms Duration (in milliseconds) for a particular table's import
# TYPE molt_fetch_table_import_duration_ms gauge
molt_fetch_table_import_duration_ms{schema="public",table="public.employees"} 3257
# HELP molt_fetch_table_overall_duration_ms Duration (in milliseconds) for a particular table's fetch.
# TYPE molt_fetch_table_overall_duration_ms gauge
molt_fetch_table_overall_duration_ms{schema="public",table="public.employees"} 5233
```