### PR TITLE
verifymetrics: added table label to verify metrics so that we can see issues by table

### DIFF
--- a/utils/formatting.go
+++ b/utils/formatting.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+func SchemaTableString(schema, table tree.Name) string {
+	return fmt.Sprintf("%s.%s", string(schema), string(table))
+}

--- a/verify/inconsistency/reporter.go
+++ b/verify/inconsistency/reporter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/molt/dbconn"
 	"github.com/cockroachdb/molt/moltlogger"
+	"github.com/cockroachdb/molt/utils"
 	"github.com/cockroachdb/molt/verify/verifymetrics"
 	"github.com/rs/zerolog"
 )
@@ -180,7 +181,7 @@ func (l FixReporter) Report(obj ReportableObject) {
 				panic(err)
 			}
 		}
-		verifymetrics.NumRowFixups.WithLabelValues("mismatching").Inc()
+		verifymetrics.NumRowFixups.WithLabelValues("mismatching", utils.SchemaTableString(obj.Schema, obj.Table)).Inc()
 	case MissingRow:
 		l.Logger.Info().
 			Str("table_schema", string(obj.Schema)).
@@ -213,7 +214,7 @@ func (l FixReporter) Report(obj ReportableObject) {
 				panic(err)
 			}
 		}
-		verifymetrics.NumRowFixups.WithLabelValues("missing").Inc()
+		verifymetrics.NumRowFixups.WithLabelValues("missing", utils.SchemaTableString(obj.Schema, obj.Table)).Inc()
 	case ExtraneousRow:
 		l.Logger.Info().
 			Str("table_schema", string(obj.Schema)).
@@ -234,7 +235,7 @@ func (l FixReporter) Report(obj ReportableObject) {
 				panic(err)
 			}
 		}
-		verifymetrics.NumRowFixups.WithLabelValues("extraneous").Inc()
+		verifymetrics.NumRowFixups.WithLabelValues("extraneous", utils.SchemaTableString(obj.Schema, obj.Table)).Inc()
 	}
 }
 

--- a/verify/verifymetrics/metrics.go
+++ b/verify/verifymetrics/metrics.go
@@ -29,7 +29,7 @@ var (
 		Subsystem: Subsystem,
 		Name:      "num_row_fixups",
 		Help:      "Number of fixups per category.",
-	}, []string{"category"})
+	}, []string{"category", "table"})
 	OverallDuration = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: Subsystem,
@@ -75,13 +75,13 @@ var (
 		Subsystem: Subsystem,
 		Name:      "row_verification_status",
 		Help:      "Status of rows that have been verified.",
-	}, []string{"status"})
-	RowsRead = promauto.NewCounter(prometheus.CounterOpts{
+	}, []string{"status", "table"})
+	RowsRead = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: Subsystem,
 		Name:      "rows_read",
 		Help:      "Rate of rows that are being read from source database.",
-	})
+	}, []string{"table"})
 
 	rowStatusCategories = []string{"extraneous", "missing", "mismatching", "mismatching_column", "success", "conditional_success"}
 	tableCategories     = []string{"verified", "missing", "extraneous"}
@@ -95,10 +95,10 @@ func init() {
 	}
 
 	for _, f := range fixupCategories {
-		NumRowFixups.WithLabelValues(f)
+		NumRowFixups.WithLabelValues(f, "overall")
 	}
 
 	for _, r := range rowStatusCategories {
-		RowStatus.WithLabelValues(r)
+		RowStatus.WithLabelValues(r, "overall")
 	}
 }


### PR DESCRIPTION
Release Note: None

As you can see here in the testing, there is now the table label:
```
molt_verify_duration_seconds 0.732952792
molt_verify_num_row_fixups{category="extraneous",table="overall"} 0
molt_verify_num_row_fixups{category="mismatching",table="overall"} 0
molt_verify_num_row_fixups{category="missing",table="overall"} 0
molt_verify_num_row_fixups{category="mismatching",table="public.employees"} 1

molt_verify_num_tables{category="extraneous"} 0
molt_verify_num_tables{category="missing"} 0
molt_verify_num_tables{category="verified"} 1

molt_verify_row_verification_status{status="conditional_success",table="overall"} 0
molt_verify_row_verification_status{status="extraneous",table="overall"} 0
molt_verify_row_verification_status{status="mismatching",table="overall"} 0
molt_verify_row_verification_status{status="mismatching_column",table="overall"} 0
molt_verify_row_verification_status{status="missing",table="overall"} 0
molt_verify_row_verification_status{status="success",table="overall"} 0
molt_verify_row_verification_status{status="success",table="public.employees"} 200000

molt_verify_rows_read{table="public.employees"} 200000
```