### PR TITLE
fetch: Add row count per file to resources

### DIFF
--- a/fetch/csv_pipe.go
+++ b/fetch/csv_pipe.go
@@ -79,6 +79,14 @@ func (p *csvPipe) Pipe(tn dbtable.Name) error {
 	}
 }
 
+<<<<<<< HEAD
+=======
+// flush flushes the current csv files when either
+// we reached the end of the file or our file limits.
+// It also sends the current number of rows processed
+// to a channel to be processed by the data storage
+// backend.
+>>>>>>> 1e7bdca (fetch: Add row count per file to blob resource)
 func (p *csvPipe) flush() error {
 	if p.csvWriter != nil {
 		p.csvWriter.Flush()

--- a/fetch/csv_pipe_test.go
+++ b/fetch/csv_pipe_test.go
@@ -135,14 +135,10 @@ multiline part"
 				zerolog.New(os.Stdout),
 				tc.flushSize,
 				tc.flushRows,
-<<<<<<< HEAD
-				func() io.WriteCloser {
-=======
 				func(numRows chan int) io.WriteCloser {
 					go func() {
 						<-numRows
 					}()
->>>>>>> 1e7bdca (fetch: Add row count per file to blob resource)
 					bufs = append(bufs, testStringBuf{})
 					return &bufs[len(bufs)-1]
 				},

--- a/fetch/csv_pipe_test.go
+++ b/fetch/csv_pipe_test.go
@@ -135,7 +135,14 @@ multiline part"
 				zerolog.New(os.Stdout),
 				tc.flushSize,
 				tc.flushRows,
+<<<<<<< HEAD
 				func() io.WriteCloser {
+=======
+				func(numRows chan int) io.WriteCloser {
+					go func() {
+						<-numRows
+					}()
+>>>>>>> 1e7bdca (fetch: Add row count per file to blob resource)
 					bufs = append(bufs, testStringBuf{})
 					return &bufs[len(bufs)-1]
 				},

--- a/fetch/datablobstorage/copy_direct.go
+++ b/fetch/datablobstorage/copy_direct.go
@@ -20,7 +20,12 @@ type copyCRDBDirect struct {
 }
 
 func (c *copyCRDBDirect) CreateFromReader(
-	ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string,
+	ctx context.Context,
+	r io.Reader,
+	table dbtable.VerifiedTable,
+	iteration int,
+	fileExt string,
+	numRows chan int,
 ) (Resource, error) {
 	conn, err := pgx.ConnectConfig(ctx, c.target.Config())
 	if err != nil {

--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -17,6 +17,7 @@ type Store interface {
 
 type Resource interface {
 	Key() (string, error)
+	NumRows() (int, error)
 	ImportURL() (string, error)
 	MarkForCleanup(ctx context.Context) error
 	Reader(ctx context.Context) (io.ReadCloser, error)

--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Store interface {
-	CreateFromReader(ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string) (Resource, error)
+	CreateFromReader(ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string, numRows chan int) (Resource, error)
 	CanBeTarget() bool
 	DefaultFlushBatchSize() int
 	Cleanup(ctx context.Context) error

--- a/fetch/datablobstorage/gcp.go
+++ b/fetch/datablobstorage/gcp.go
@@ -52,10 +52,13 @@ func (s *gcpStore) CreateFromReader(
 	if err := wc.Close(); err != nil {
 		return nil, err
 	}
-	s.logger.Debug().Str("file", key).Msgf("gcp file creation complete complete")
+
+	rows := <-numRows
+	s.logger.Debug().Str("file", key).Int("rows", rows).Msgf("gcp file creation complete complete")
 	return &gcpResource{
 		store: s,
 		key:   key,
+		rows:  rows,
 	}, nil
 }
 
@@ -92,6 +95,10 @@ func (r *gcpResource) ImportURL() (string, error) {
 
 func (r *gcpResource) Key() (string, error) {
 	return r.key, nil
+}
+
+func (r *gcpResource) NumRows() (int, error) {
+	return r.rows, nil
 }
 
 func (r *gcpResource) Reader(ctx context.Context) (io.ReadCloser, error) {

--- a/fetch/datablobstorage/gcp.go
+++ b/fetch/datablobstorage/gcp.go
@@ -37,7 +37,12 @@ func NewGCPStore(
 }
 
 func (s *gcpStore) CreateFromReader(
-	ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string,
+	ctx context.Context,
+	r io.Reader,
+	table dbtable.VerifiedTable,
+	iteration int,
+	fileExt string,
+	numRows chan int,
 ) (Resource, error) {
 	key := fmt.Sprintf("%s/part_%08d.%s", table.SafeString(), iteration, fileExt)
 	if s.bucketPath != "" {
@@ -82,6 +87,7 @@ func (r *gcpStore) TelemetryName() string {
 type gcpResource struct {
 	store *gcpStore
 	key   string
+	rows  int
 }
 
 func (r *gcpResource) ImportURL() (string, error) {

--- a/fetch/datablobstorage/local.go
+++ b/fetch/datablobstorage/local.go
@@ -105,7 +105,8 @@ func (l *localStore) CreateFromReader(
 		if err != nil {
 			if err == io.EOF {
 				logger.Debug().Msgf("wrote file")
-				return &localResource{path: p, store: l}, nil
+				rows := <-numRows
+				return &localResource{path: p, store: l, rows: rows}, nil
 			}
 			return nil, err
 		}
@@ -167,6 +168,10 @@ func (l *localResource) Key() (string, error) {
 		return "", errors.Wrapf(err, "error finding relative path")
 	}
 	return rel, nil
+}
+
+func (l *localResource) NumRows() (int, error) {
+	return l.rows, nil
 }
 
 func (l *localResource) MarkForCleanup(ctx context.Context) error {

--- a/fetch/datablobstorage/local.go
+++ b/fetch/datablobstorage/local.go
@@ -86,7 +86,12 @@ func getLocalIP() string {
 }
 
 func (l *localStore) CreateFromReader(
-	ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string,
+	ctx context.Context,
+	r io.Reader,
+	table dbtable.VerifiedTable,
+	iteration int,
+	fileExt string,
+	numRows chan int,
 ) (Resource, error) {
 	baseDir := path.Join(l.basePath, table.SafeString())
 	if err := os.MkdirAll(baseDir, os.ModePerm); err != nil {
@@ -145,6 +150,7 @@ func (l *localStore) TelemetryName() string {
 type localResource struct {
 	path  string
 	store *localStore
+	rows  int
 }
 
 func (l *localResource) Reader(ctx context.Context) (io.ReadCloser, error) {

--- a/fetch/datablobstorage/s3.go
+++ b/fetch/datablobstorage/s3.go
@@ -49,6 +49,10 @@ func (s *s3Resource) Key() (string, error) {
 	return s.key, nil
 }
 
+func (s *s3Resource) NumRows() (int, error) {
+	return s.rows, nil
+}
+
 func (s *s3Resource) MarkForCleanup(ctx context.Context) error {
 	s.store.batchDelete.Lock()
 	defer s.store.batchDelete.Unlock()


### PR DESCRIPTION
This commit adds a row count field to ever storage resource. The reason for this is mainly for progress tracking but more specfically for the IMPORT use case where we are not able to know the number of rows imported. We now have this information since each resource has its own file count.

Release note: None