### PR TITLE
fetch: added in status and exception database helpers

### DIFF
--- a/fetch/status/exceptions.go
+++ b/fetch/status/exceptions.go
@@ -1,0 +1,66 @@
+package status
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/util/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+const createExceptionsTable = `CREATE TABLE IF NOT EXISTS _molt_fetch_exception (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	fetch_id UUID NOT NULL REFERENCES _molt_fetch_status (id),
+    table_name STRING,
+    schema_name STRING,
+    message STRING,
+    sql_state INT,
+    file_name STRING,
+    command STRING,
+    time TIMESTAMP,
+	INDEX(fetch_id, sql_state)
+);
+`
+
+type ExceptionLog struct {
+	ID       uuid.UUID
+	FetchID  uuid.UUID
+	Table    string
+	Schema   string
+	Message  string
+	SQLState int
+	FileName string
+	Command  string
+	Time     time.Time
+}
+
+func (e *ExceptionLog) CreateEntry(ctx context.Context, conn *pgx.Conn) error {
+	curTime := time.Now().UTC()
+	query := `INSERT INTO _molt_fetch_exception (fetch_id, table_name, schema_name, message, sql_state, file_name, command, time) VALUES(@fetch_id, @table_name, @schema_name, @message, @sql_state, @file_name, @command, @time) RETURNING id`
+	args := pgx.NamedArgs{
+		"fetch_id":    e.FetchID,
+		"table_name":  e.Table,
+		"schema_name": e.Schema,
+		"message":     e.Message,
+		"command":     e.Command,
+		"time":        curTime,
+	}
+
+	if e.SQLState > 0 {
+		args["sql_state"] = e.SQLState
+	}
+
+	if strings.TrimSpace(e.FileName) != "" {
+		args["file_name"] = e.FileName
+	}
+
+	row := conn.QueryRow(ctx, query, args)
+
+	if err := row.Scan(&e.ID); err != nil {
+		return err
+	}
+	e.Time = curTime
+
+	return nil
+}

--- a/fetch/status/exceptions_test.go
+++ b/fetch/status/exceptions_test.go
@@ -1,0 +1,72 @@
+package status
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/util/uuid"
+	"github.com/cockroachdb/molt/dbconn"
+	"github.com/cockroachdb/molt/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateExceptionEntry(t *testing.T) {
+	ctx := context.Background()
+	dbName := "fetch_test_status"
+
+	t.Run("succesful create", func(t *testing.T) {
+		s := &FetchStatus{
+			Name:          "run 1",
+			Status:        "IN PROGRESS",
+			StartedAt:     time.Now(),
+			FinishedAt:    time.Now(),
+			SourceDialect: "postgres",
+		}
+		conn, err := dbconn.TestOnlyCleanDatabase(ctx, "target", testutils.CRDBConnStr(), dbName)
+		require.NoError(t, err)
+		pgConn := conn.(*dbconn.PGConn).Conn
+		// Setup the tables that we need to write for status.
+		require.NoError(t, CreateStatusAndExceptionTables(ctx, pgConn))
+
+		// Create entry first.
+		err = s.CreateEntry(ctx, pgConn)
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, s.ID)
+
+		e := ExceptionLog{
+			FetchID:  s.ID,
+			FileName: "test.log",
+			Table:    "employees",
+			Schema:   "public",
+			Message:  "this all failed",
+			SQLState: 1000,
+			Command:  "SELECT VERSION()",
+			Time:     time.Now(),
+		}
+		err = e.CreateEntry(ctx, pgConn)
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, e.ID)
+	})
+
+	t.Run("failed because fetch ID invalid", func(t *testing.T) {
+		conn, err := dbconn.TestOnlyCleanDatabase(ctx, "target", testutils.CRDBConnStr(), dbName)
+		require.NoError(t, err)
+		pgConn := conn.(*dbconn.PGConn).Conn
+		// Setup the tables that we need to write for status.
+		require.NoError(t, CreateStatusAndExceptionTables(ctx, pgConn))
+
+		e := ExceptionLog{
+			FetchID:  uuid.Nil,
+			FileName: "test.log",
+			Table:    "employees",
+			Schema:   "public",
+			Message:  "this all failed",
+			SQLState: 1000,
+			Command:  "SELECT VERSION()",
+			Time:     time.Now(),
+		}
+		err = e.CreateEntry(ctx, pgConn)
+		require.EqualError(t, err, "ERROR: insert on table \"_molt_fetch_exception\" violates foreign key constraint \"_molt_fetch_exception_fetch_id_fkey\" (SQLSTATE 23503)")
+	})
+}

--- a/fetch/status/status.go
+++ b/fetch/status/status.go
@@ -1,0 +1,79 @@
+package status
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/util/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	StatusInProgress = "IN PROGRESS"
+	StatusFailed     = "FAILED"
+	StatusSucceeded  = "SUCCEEDED"
+)
+
+const createStatusTable = `CREATE TABLE IF NOT EXISTS _molt_fetch_status (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name STRING,
+    status STRING,
+    started_at TIMESTAMP,
+    finished_at TIMESTAMP,
+    source_dialect STRING
+);
+`
+
+type FetchStatus struct {
+	ID            uuid.UUID
+	Name          string
+	Status        string
+	StartedAt     time.Time
+	FinishedAt    time.Time
+	SourceDialect string
+}
+
+func (s *FetchStatus) CreateEntry(ctx context.Context, conn *pgx.Conn) error {
+	startTime := time.Now().UTC()
+	query := `INSERT INTO _molt_fetch_status (name, status, started_at, source_dialect) VALUES(@name, @status, @started_at, @source_dialect) RETURNING id, status`
+	args := pgx.NamedArgs{
+		"name":           s.Name,
+		"source_dialect": s.SourceDialect,
+		"status":         StatusInProgress,
+		"started_at":     startTime,
+	}
+	row := conn.QueryRow(ctx, query, args)
+
+	if err := row.Scan(&s.ID, &s.Status); err != nil {
+		return err
+	}
+
+	s.StartedAt = startTime
+	return nil
+}
+
+func (s *FetchStatus) markComplete(ctx context.Context, conn *pgx.Conn, status string) error {
+	endTime := time.Now().UTC()
+	query := `UPDATE _molt_fetch_status SET status=@status, finished_at=@finished_at WHERE id=@id`
+	args := pgx.NamedArgs{
+		"id":          s.ID,
+		"status":      status,
+		"finished_at": endTime,
+	}
+
+	if _, err := conn.Exec(ctx, query, args); err != nil {
+		return err
+	}
+
+	s.Status = status
+	s.FinishedAt = endTime
+	return nil
+}
+
+func (s *FetchStatus) MarkSuccessful(ctx context.Context, conn *pgx.Conn) error {
+	return s.markComplete(ctx, conn, StatusSucceeded)
+}
+
+func (s *FetchStatus) MarkFailed(ctx context.Context, conn *pgx.Conn) error {
+	return s.markComplete(ctx, conn, StatusFailed)
+}

--- a/fetch/status/status_test.go
+++ b/fetch/status/status_test.go
@@ -1,0 +1,104 @@
+package status
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/util/uuid"
+	"github.com/cockroachdb/molt/dbconn"
+	"github.com/cockroachdb/molt/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateStatusEntry(t *testing.T) {
+	ctx := context.Background()
+	dbName := "fetch_test_status"
+
+	s := &FetchStatus{
+		Name:          "run 1",
+		Status:        "IN PROGRESS",
+		StartedAt:     time.Now(),
+		FinishedAt:    time.Now(),
+		SourceDialect: "postgres",
+	}
+	conn, err := dbconn.TestOnlyCleanDatabase(ctx, "target", testutils.CRDBConnStr(), dbName)
+	require.NoError(t, err)
+	pgConn := conn.(*dbconn.PGConn).Conn
+	// Setup the tables that we need to write for status.
+	require.NoError(t, CreateStatusAndExceptionTables(ctx, pgConn))
+
+	// Verify we can create one entry.
+	err = s.CreateEntry(ctx, pgConn)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, s.ID)
+
+	// Verify we can create the entry after the first one.
+	err = s.CreateEntry(ctx, pgConn)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, s.ID)
+
+	err = s.CreateEntry(ctx, pgConn)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, s.ID)
+}
+
+func TestMarkSuccessful(t *testing.T) {
+	ctx := context.Background()
+	dbName := "fetch_test_status"
+
+	s := &FetchStatus{
+		Name:          "run 1",
+		Status:        "",
+		StartedAt:     time.Now(),
+		FinishedAt:    time.Now(),
+		SourceDialect: "postgres",
+	}
+	conn, err := dbconn.TestOnlyCleanDatabase(ctx, "target", testutils.CRDBConnStr(), dbName)
+	require.NoError(t, err)
+	pgConn := conn.(*dbconn.PGConn).Conn
+	// Setup the tables that we need to write for status.
+	require.NoError(t, CreateStatusAndExceptionTables(ctx, pgConn))
+
+	// Verify we can create one entry.
+	err = s.CreateEntry(ctx, pgConn)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, s.ID)
+	require.Equal(t, StatusInProgress, s.Status)
+
+	// Verify that this is now successful.
+	err = s.MarkSuccessful(ctx, pgConn)
+	require.NoError(t, err)
+	require.Equal(t, StatusSucceeded, s.Status)
+	require.Equal(t, false, s.FinishedAt.IsZero())
+}
+
+func TestMarkFailed(t *testing.T) {
+	ctx := context.Background()
+	dbName := "fetch_test_status"
+
+	s := &FetchStatus{
+		Name:          "run 1",
+		Status:        "",
+		StartedAt:     time.Now(),
+		FinishedAt:    time.Now(),
+		SourceDialect: "postgres",
+	}
+	conn, err := dbconn.TestOnlyCleanDatabase(ctx, "target", testutils.CRDBConnStr(), dbName)
+	require.NoError(t, err)
+	pgConn := conn.(*dbconn.PGConn).Conn
+	// Setup the tables that we need to write for status.
+	require.NoError(t, CreateStatusAndExceptionTables(ctx, pgConn))
+
+	// Verify we can create one entry.
+	err = s.CreateEntry(ctx, pgConn)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, s.ID)
+	require.Equal(t, StatusInProgress, s.Status)
+
+	// Verify that this is now successful.
+	err = s.MarkFailed(ctx, pgConn)
+	require.NoError(t, err)
+	require.Equal(t, StatusFailed, s.Status)
+	require.Equal(t, false, s.FinishedAt.IsZero())
+}

--- a/fetch/status/utils.go
+++ b/fetch/status/utils.go
@@ -1,0 +1,19 @@
+package status
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func CreateStatusAndExceptionTables(ctx context.Context, conn *pgx.Conn) error {
+	if _, err := conn.Exec(ctx, createStatusTable); err != nil {
+		return err
+	}
+
+	if _, err := conn.Exec(ctx, createExceptionsTable); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
The helpers include mapping structs, helpers to create and update resources in the database, constants to represent different states.

Resolves: CC-26805
Release Note: None

**Tested with this bit of code**
```
 // TODO: logic for seeing source dialect
targetPgxConn := conns[1].(*dbconn.PGConn).Conn
if err := status.CreateStatusAndExceptionTables(ctx, targetPgxConn); err != nil {
    return err
}
fetchStatus := status.FetchStatus{
    Name:          "the-best",
    Status:        status.StatusInProgress,
    StartedAt:     time.Now(),
    SourceDialect: "PostgreSQL",
}
if err := fetchStatus.Create(ctx, targetPgxConn); err != nil {
    return err
}
fmt.Println(fetchStatus.ID)
fetchException := status.ExceptionLog{
    FetchID:  fetchStatus.ID,
    FileName: "yo.log",
    Table:    "employees",
    Schema:   "public",
    Message:  "it just all failed",
    SQLState: 1000,
    Command:  "SELECT *",
    Time:     time.Now(),
}
if err := fetchException.Create(ctx, targetPgxConn); err != nil {
    return err
}
fmt.Println(fetchException.ID)
fetchStatus.MarkFailed(ctx, targetPgxConn)
```

Results look like this in the database:
```
root@:26257/defaultdb> SELECT * FROM _molt_fetch_exception;
                   id                  |               fetch_id               | table_name | schema_name |      message       | sql_state | file_name | command  |            time
---------------------------------------+--------------------------------------+------------+-------------+--------------------+-----------+-----------+----------+-----------------------------
  70e973c1-8382-4c25-a407-9eaaa17e331e | f4ed9eae-1ba6-47a6-86ba-eee273633931 | employees  | public      | it just all failed |      1000 | yo.log    | SELECT * | 2024-01-17 16:29:50.234931

root@:26257/defaultdb> SELECT * FROM _molt_fetch_status;
                   id                  |   name   |   status    |         started_at         | finished_at | source_dialect
---------------------------------------+----------+-------------+----------------------------+-------------+-----------------
  dfaf7f39-520c-4860-9c2d-76bc88de7e2f | the-best | IN PROGRESS | 2024-01-17 16:29:26.172858 | NULL        | PostgreSQL
  f4ed9eae-1ba6-47a6-86ba-eee273633931 | the-best | IN PROGRESS | 2024-01-17 16:29:50.232368 | NULL        | PostgreSQL


root@:26257/defaultdb> SELECT * FROM _molt_fetch_status ORDER BY started_at DESC;
                   id                  |   name   |   status    |         started_at         |        finished_at         | source_dialect
---------------------------------------+----------+-------------+----------------------------+----------------------------+-----------------
  26788893-8f7b-466d-a580-5e9b85e2f898 | the-best | FAILED      | 2024-01-17 16:38:15.82192  | 2024-01-17 16:38:15.827129 | PostgreSQL
  ebb0b30a-f213-4d0c-bf93-dd571273e593 | the-best | SUCCEEDED   | 2024-01-17 16:37:21.293364 | 2024-01-17 16:37:21.301917 | PostgreSQL
  f4ed9eae-1ba6-47a6-86ba-eee273633931 | the-best | IN PROGRESS | 2024-01-17 16:29:50.232368 | NULL                       | PostgreSQL
  dfaf7f39-520c-4860-9c2d-76bc88de7e2f | the-best | IN PROGRESS | 2024-01-17 16:29:26.172858 | NULL                       | PostgreSQL
```