### PR TITLE
fetch: added in testing knobs to simulate corrupted CSV failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ build_molt_cli:
 
 sync_hooks:
 	cp -a .githooks/ .git/hooks/
+
+rewrite_fetch_tests:
+	go test -v -run ^TestDataDriven github.com/cockroachdb/molt/fetch --rewrite

--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
 	"github.com/cockroachdb/molt/fetch/fetchmetrics"
 	"github.com/cockroachdb/molt/moltlogger"
+	"github.com/cockroachdb/molt/testutils"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag/v2"
 	"golang.org/x/oauth2/google"
@@ -105,6 +106,7 @@ func Command() *cobra.Command {
 				conns,
 				src,
 				cmdutil.TableFilter(),
+				testutils.FetchTestingKnobs{},
 			)
 
 			if err != nil {

--- a/fetch/export_table.go
+++ b/fetch/export_table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/fetch/datablobstorage"
 	"github.com/cockroachdb/molt/fetch/dataexport"
+	"github.com/cockroachdb/molt/testutils"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 )
@@ -38,6 +39,7 @@ func exportTable(
 	sqlSrc dataexport.Source,
 	datasource datablobstorage.Store,
 	table dbtable.VerifiedTable,
+	testingKnobs testutils.FetchTestingKnobs,
 ) (exportResult, error) {
 	importFileExt := "csv"
 	if cfg.Compression == compression.GZIP {
@@ -100,6 +102,8 @@ func exportTable(
 		return wrappedWriter
 	})
 
+	// This is so we can simulate corrupted CSVs for testing.
+	pipe.testingKnobs = testingKnobs
 	err := pipe.Pipe(table.Name)
 	// Wait for the resource wait group to complete. It may output an error
 	// that is not captured in the pipe.

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -77,6 +77,7 @@ func TestDataDriven(t *testing.T) {
 						live := false
 						direct := false
 						compress := false
+						corruptCSVFile := false
 
 						for _, cmd := range d.CmdArgs {
 							switch cmd.Key {
@@ -88,6 +89,8 @@ func TestDataDriven(t *testing.T) {
 								direct = true
 							case "compress":
 								compress = true
+							case "corrupt-csv":
+								corruptCSVFile = true
 							default:
 								t.Errorf("unknown key %s", cmd.Key)
 							}
@@ -158,6 +161,11 @@ func TestDataDriven(t *testing.T) {
 							compressionFlag = compression.GZIP
 						}
 
+						knobs := testutils.FetchTestingKnobs{}
+						if corruptCSVFile {
+							knobs.TriggerCorruptCSVFile = true
+						}
+
 						err = Fetch(
 							ctx,
 							Config{
@@ -172,6 +180,7 @@ func TestDataDriven(t *testing.T) {
 							conns,
 							src,
 							filter,
+							knobs,
 						)
 						if expectError {
 							require.Error(t, err)

--- a/fetch/testdata/pg/exceptions.ddt
+++ b/fetch/testdata/pg/exceptions.ddt
@@ -53,3 +53,27 @@ SELECT table_name, message, sql_state, file_name, stage FROM _molt_fetch_excepti
 table_name	message	sql_state	file_name	stage
 tbl1	duplicate key value violates unique constraint "tbl1_pkey"; Key (id)=(11) already exists.	23505	part_00000001.csv	data_load
 tag: SELECT 1
+
+fetch live notruncate expect-error corrupt-csv
+----
+ERROR: read CSV record: record on line 2: wrong number of fields (SQLSTATE 22P04)
+
+query target
+SELECT table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception WHERE sql_state='22P04'
+----
+[target]:
+table_name	message	sql_state	file_name	stage
+tbl1	read CSV record: record on line 2: wrong number of fields; 	22P04	part_00000001.csv	data_load
+tag: SELECT 1
+
+fetch notruncate expect-error corrupt-csv
+----
+error importing data: ERROR: http://host.docker.internal:4040/public.tbl1/part_00000001.csv: error parsing row 2: expected 2 fields, got 6 (row: this,should,lead,to,an,error) (SQLSTATE XXUUU)
+
+query target
+SELECT table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception WHERE sql_state='XXUUU'
+----
+[target]:
+table_name	message	sql_state	file_name	stage
+tbl1	http://host.docker.internal:4040/public.tbl1/part_00000001.csv: error parsing row 2: expected 2 fields, got 6 (row: this,should,lead,to,an,error); 	XXUUU	part_00000001.csv	data_load
+tag: SELECT 1

--- a/fetch/testdata/pg/exceptions.ddt
+++ b/fetch/testdata/pg/exceptions.ddt
@@ -68,12 +68,12 @@ tag: SELECT 1
 
 fetch notruncate expect-error corrupt-csv
 ----
-error importing data: ERROR: http://host.docker.internal:4040/public.tbl1/part_00000001.csv: error parsing row 2: expected 2 fields, got 6 (row: this,should,lead,to,an,error) (SQLSTATE XXUUU)
+error importing data: ERROR: http://localhost:4040/public.tbl1/part_00000001.csv: error parsing row 2: expected 2 fields, got 6 (row: this,should,lead,to,an,error) (SQLSTATE XXUUU)
 
 query target
 SELECT table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception WHERE sql_state='XXUUU'
 ----
 [target]:
 table_name	message	sql_state	file_name	stage
-tbl1	http://host.docker.internal:4040/public.tbl1/part_00000001.csv: error parsing row 2: expected 2 fields, got 6 (row: this,should,lead,to,an,error); 	XXUUU	part_00000001.csv	data_load
+tbl1	http://localhost:4040/public.tbl1/part_00000001.csv: error parsing row 2: expected 2 fields, got 6 (row: this,should,lead,to,an,error); 	XXUUU	part_00000001.csv	data_load
 tag: SELECT 1

--- a/testutils/knobs.go
+++ b/testutils/knobs.go
@@ -1,0 +1,6 @@
+package testutils
+
+type FetchTestingKnobs struct {
+	// Used to simulate testing when the CSV input file is wrong.
+	TriggerCorruptCSVFile bool
+}


### PR DESCRIPTION
Added in testing knobs structure and formatting so that we can properly simulate errors. Currently, the corrupt CSV failure mode is simulated for better testing.

Resolves: CC-26918
Release Note: None