### PR TITLE
[CC-26908] fetch: Add new flags for continuations

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -23,13 +23,15 @@ import (
 )
 
 type Config struct {
-	FlushSize   int
-	FlushRows   int
-	Cleanup     bool
-	Live        bool
-	Truncate    bool
-	Concurrency int
-
+	FlushSize            int
+	FlushRows            int
+	Cleanup              bool
+	Live                 bool
+	Truncate             bool
+	Concurrency          int
+	FetchID              string
+	ContinuationToken    string
+	ContinuationFileName string
 	// TestOnly means this fetch attempt is just for test, and hence all time/duration
 	// stats are deterministic.
 	TestOnly bool


### PR DESCRIPTION
This commit adds the 3 new flags that will be needed for the continuation process work. Fetch-id is the parent flag and is a dependency for the child flags continuation-token and continuation-file-name.

Release note: None