### PR TITLE
fetch: fix csv pipe deadlock + add row count per file to blob resource

### DIFF
--- a/fetch/csv_pipe_test.go
+++ b/fetch/csv_pipe_test.go
@@ -135,12 +135,12 @@ multiline part"
 				zerolog.New(os.Stdout),
 				tc.flushSize,
 				tc.flushRows,
-				func(numRows chan int) io.WriteCloser {
+				func(numRows chan int) (io.WriteCloser, error) {
 					go func() {
 						<-numRows
 					}()
 					bufs = append(bufs, testStringBuf{})
-					return &bufs[len(bufs)-1]
+					return &bufs[len(bufs)-1], nil
 				},
 			)
 			require.NoError(t, pipe.Pipe(dbtable.Name{Schema: "test", Table: "test"}))

--- a/fetch/csv_pipe_test.go
+++ b/fetch/csv_pipe_test.go
@@ -135,7 +135,10 @@ multiline part"
 				zerolog.New(os.Stdout),
 				tc.flushSize,
 				tc.flushRows,
-				func() io.WriteCloser {
+				func(numRows chan int) io.WriteCloser {
+					go func() {
+						<-numRows
+					}()
 					bufs = append(bufs, testStringBuf{})
 					return &bufs[len(bufs)-1]
 				},

--- a/fetch/datablobstorage/copy_direct.go
+++ b/fetch/datablobstorage/copy_direct.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/fetch/internal/dataquery"
 	"github.com/cockroachdb/molt/fetch/status"
+	"github.com/cockroachdb/molt/testutils"
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 )
@@ -20,6 +21,8 @@ type copyCRDBDirect struct {
 	target *pgx.Conn
 }
 
+const DirectCopyWriterMockErrMsg = "forced error for direct copy"
+
 func (c *copyCRDBDirect) CreateFromReader(
 	ctx context.Context,
 	r io.Reader,
@@ -27,15 +30,23 @@ func (c *copyCRDBDirect) CreateFromReader(
 	iteration int,
 	fileExt string,
 	numRows chan int,
+	testingKnobs testutils.FetchTestingKnobs,
 ) (Resource, error) {
 	conn, err := pgx.ConnectConfig(ctx, c.target.Config())
 	if err != nil {
 		return nil, err
 	}
+	if testingKnobs.FailedWriteToBucket.FailedBeforeReadFromPipe {
+		return nil, errors.New(DirectCopyWriterMockErrMsg)
+	}
+
 	c.logger.Debug().Int("batch", iteration).Msgf("csv batch starting")
 	if _, err := conn.PgConn().CopyFrom(ctx, r, dataquery.CopyFrom(table)); err != nil {
 		pgErr := status.MaybeReportException(ctx, c.logger, conn, table.Name, err, "" /* fileName */, status.StageDataLoad)
 		return nil, errors.CombineErrors(pgErr, conn.Close(ctx))
+	}
+	if testingKnobs.FailedWriteToBucket.FailedAfterReadFromPipe {
+		return nil, errors.New(DirectCopyWriterMockErrMsg)
 	}
 	c.logger.Debug().Int("batch", iteration).Msgf("csv batch complete")
 	return nil, conn.Close(ctx)

--- a/fetch/datablobstorage/copy_direct.go
+++ b/fetch/datablobstorage/copy_direct.go
@@ -21,7 +21,12 @@ type copyCRDBDirect struct {
 }
 
 func (c *copyCRDBDirect) CreateFromReader(
-	ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string,
+	ctx context.Context,
+	r io.Reader,
+	table dbtable.VerifiedTable,
+	iteration int,
+	fileExt string,
+	numRows chan int,
 ) (Resource, error) {
 	conn, err := pgx.ConnectConfig(ctx, c.target.Config())
 	if err != nil {

--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -19,7 +19,7 @@ type Store interface {
 	// CSVs from the data export process. It will create the file and upload
 	// it to the respetive data store and return the resource object which
 	// will be used in the data import phase.
-	CreateFromReader(ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string) (Resource, error)
+	CreateFromReader(ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string, numRows chan int) (Resource, error)
 	// ListFromContinuationPoint is used when restarting Fetch from
 	// a continuation point. It will query the respective data store
 	// and create the slice of resources that will be used by the
@@ -35,6 +35,7 @@ type Store interface {
 
 type Resource interface {
 	Key() (string, error)
+	Rows() int
 	ImportURL() (string, error)
 	MarkForCleanup(ctx context.Context) error
 	Reader(ctx context.Context) (io.ReadCloser, error)

--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -5,7 +5,13 @@ import (
 	"fmt"
 	"io"
 
+	"cloud.google.com/go/storage"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/molt/dbtable"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+	"golang.org/x/oauth2/google"
 )
 
 type Store interface {
@@ -47,4 +53,126 @@ func getKeyAndPrefix(fileName, bucketPath string, table dbtable.VerifiedTable) (
 		prefix = fmt.Sprintf("%s/%s", bucketPath, table.SafeString())
 	}
 	return key, prefix
+}
+
+type DirectCopyPayload struct {
+	TargetConnForCopy *pgx.Conn
+}
+
+type LocalPathPayload struct {
+	LocalPath               string
+	LocalPathListenAddr     string
+	LocalPathCRDBAccessAddr string
+}
+
+type GCPPayload struct {
+	GCPBucket  string
+	BucketPath string
+}
+
+type S3Payload struct {
+	S3Bucket   string
+	BucketPath string
+}
+
+type DatastoreCreationPayload struct {
+	DirectCopyPl *DirectCopyPayload
+	GCPPl        *GCPPayload
+	S3Pl         *S3Payload
+	LocalPathPl  *LocalPathPayload
+
+	logger zerolog.Logger
+}
+
+func GenerateDatastore(
+	ctx context.Context, cfg any, logger zerolog.Logger, testFailedWriteToBucket bool,
+) (Store, error) {
+	var src Store
+	var err error
+
+	switch t := cfg.(type) {
+	case *DirectCopyPayload:
+		src = NewCopyCRDBDirect(logger, t.TargetConnForCopy)
+	case *GCPPayload:
+		var creds *google.Credentials
+		var err error
+		var emptyClient storage.Client
+		gcpClient := &emptyClient
+		// For this test, we don't need the real credentials or client.
+		if !testFailedWriteToBucket {
+			creds, err = google.FindDefaultCredentials(ctx)
+			if err != nil {
+				return nil, err
+			}
+			gcpClient, err = storage.NewClient(ctx)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to make new gcp client")
+			}
+		}
+		src = NewGCPStore(logger, gcpClient, creds, t.GCPBucket, t.BucketPath)
+	case *S3Payload:
+		var sess *session.Session
+		var creds credentials.Value
+		var err error
+
+		if sess, err = session.NewSession(); err != nil {
+			return nil, err
+		}
+		if t.Region != "" {
+			sess.Config.Region = &t.Region
+		}
+		// For this test, we don't need the real credentials or client.
+		if !testFailedWriteToBucket {
+			if creds, err = sess.Config.Credentials.Get(); err != nil {
+				return nil, err
+			}
+		}
+		src = NewS3Store(logger, sess, creds, t.S3Bucket, t.BucketPath)
+	case *LocalPathPayload:
+		src, err = NewLocalStore(logger, t.LocalPath, t.LocalPathListenAddr, t.LocalPathCRDBAccessAddr)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.AssertionFailedf("data source must be configured (--s3-bucket, --gcp-bucket, --direct-copy)")
+	}
+
+	return src, err
+}
+
+func GenerateDatastoreNew(ctx context.Context, cfg DatastoreCreationPayload) (Store, error) {
+	var src Store
+	var err error
+	switch {
+	case cfg.DirectCopyPl != nil:
+		src = NewCopyCRDBDirect(cfg.logger, cfg.DirectCopyPl.TargetConnForCopy)
+	case cfg.GCPPl != nil:
+		creds, err := google.FindDefaultCredentials(ctx)
+		if err != nil {
+			return nil, err
+		}
+		gcpClient, err := storage.NewClient(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		src = NewGCPStore(cfg.logger, gcpClient, creds, cfg.GCPPl.GCPBucket, cfg.GCPPl.BucketPath)
+	case cfg.S3Pl != nil:
+		sess, err := session.NewSession()
+		if err != nil {
+			return nil, err
+		}
+		creds, err := sess.Config.Credentials.Get()
+		if err != nil {
+			return nil, err
+		}
+		src = NewS3Store(cfg.logger, sess, creds, cfg.S3Pl.S3Bucket, cfg.S3Pl.BucketPath)
+	case cfg.LocalPathPl != nil:
+		src, err = NewLocalStore(cfg.logger, cfg.LocalPathPl.LocalPath, cfg.LocalPathPl.LocalPathListenAddr, cfg.LocalPathPl.LocalPathCRDBAccessAddr)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.AssertionFailedf("data source must be configured (--s3-bucket, --gcp-bucket, --direct-copy)")
+	}
+	return src, nil
 }

--- a/fetch/datablobstorage/gcp_test.go
+++ b/fetch/datablobstorage/gcp_test.go
@@ -5,11 +5,9 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
-	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/iterator"
 )
 
 func TestGCPResource_ImportURL(t *testing.T) {
@@ -38,41 +36,6 @@ func TestGCPResource_ImportURL(t *testing.T) {
 			require.Equal(t, tc.expected, u)
 		})
 	}
-}
-
-type gcpClientMock struct {
-	stiface.Client
-	mock.Mock
-}
-type gcpBucketMock struct {
-	stiface.BucketHandle
-	mock.Mock
-}
-type gcpObjectITMock struct {
-	stiface.ObjectIterator
-	i    int
-	next []storage.ObjectAttrs
-}
-
-func (m *gcpClientMock) Bucket(name string) stiface.BucketHandle {
-	args := m.Called(name)
-	return args.Get(0).(*gcpBucketMock)
-}
-
-func (m *gcpBucketMock) Objects(ctx context.Context, q *storage.Query) (it stiface.ObjectIterator) {
-	args := m.Called(ctx, q)
-	return args.Get(0).(*gcpObjectITMock)
-}
-
-func (it *gcpObjectITMock) Next() (a *storage.ObjectAttrs, err error) {
-	if it.i == len(it.next) {
-		err = iterator.Done
-		return
-	}
-
-	a = &it.next[it.i]
-	it.i += 1
-	return
 }
 
 func TestListFromContinuationPointGCP(t *testing.T) {

--- a/fetch/datablobstorage/gcp_testutil.go
+++ b/fetch/datablobstorage/gcp_testutil.go
@@ -1,0 +1,59 @@
+package datablobstorage
+
+import (
+	"context"
+
+	"cloud.google.com/go/storage"
+	"github.com/cockroachdb/errors"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/api/iterator"
+)
+
+type gcpClientMock struct {
+	stiface.Client
+	mock.Mock
+}
+type gcpBucketMock struct {
+	stiface.BucketHandle
+	mock.Mock
+}
+type gcpObjectITMock struct {
+	stiface.ObjectIterator
+	i    int
+	next []storage.ObjectAttrs
+}
+
+func (m *gcpClientMock) Bucket(name string) stiface.BucketHandle {
+	args := m.Called(name)
+	return args.Get(0).(*gcpBucketMock)
+}
+
+func (m *gcpBucketMock) Objects(ctx context.Context, q *storage.Query) (it stiface.ObjectIterator) {
+	args := m.Called(ctx, q)
+	return args.Get(0).(*gcpObjectITMock)
+}
+
+func (it *gcpObjectITMock) Next() (a *storage.ObjectAttrs, err error) {
+	if it.i == len(it.next) {
+		err = iterator.Done
+		return
+	}
+
+	a = &it.next[it.i]
+	it.i += 1
+	return
+}
+
+// GCPStorageWriterMock is to mock a gcp storage that always fail to upload to
+// the bucket. We use it to simulate a disastrous edge case and ensure that
+// the error in this case would be properly propagated.
+type GCPStorageWriterMock struct {
+	*storage.Writer
+}
+
+const GCPWriterMockErrMsg = "forced error for gcp storage writer"
+
+func (w *GCPStorageWriterMock) Write(p []byte) (n int, err error) {
+	return 0, errors.Newf(GCPWriterMockErrMsg)
+}

--- a/fetch/datablobstorage/s3.go
+++ b/fetch/datablobstorage/s3.go
@@ -34,6 +34,7 @@ type s3Resource struct {
 	session *session.Session
 	store   *s3Store
 	key     string
+	rows    int
 }
 
 func (s *s3Resource) ImportURL() (string, error) {
@@ -48,6 +49,10 @@ func (s *s3Resource) ImportURL() (string, error) {
 
 func (s *s3Resource) Key() (string, error) {
 	return s.key, nil
+}
+
+func (s *s3Resource) Rows() int {
+	return s.rows
 }
 
 func (s *s3Resource) MarkForCleanup(ctx context.Context) error {
@@ -102,7 +107,12 @@ func NewS3Store(
 }
 
 func (s *s3Store) CreateFromReader(
-	ctx context.Context, r io.Reader, table dbtable.VerifiedTable, iteration int, fileExt string,
+	ctx context.Context,
+	r io.Reader,
+	table dbtable.VerifiedTable,
+	iteration int,
+	fileExt string,
+	numRows chan int,
 ) (Resource, error) {
 	key := fmt.Sprintf("%s/part_%08d.%s", table.SafeString(), iteration, fileExt)
 	if s.bucketPath != "" {
@@ -117,11 +127,14 @@ func (s *s3Store) CreateFromReader(
 	}); err != nil {
 		return nil, err
 	}
-	s.logger.Debug().Str("file", key).Msgf("s3 file creation batch complete")
+
+	rows := <-numRows
+	s.logger.Debug().Str("file", key).Int("rows", rows).Msgf("s3 file creation batch complete")
 	return &s3Resource{
 		session: s.session,
 		store:   s,
 		key:     key,
+		rows:    rows,
 	}, nil
 }
 

--- a/fetch/datablobstorage/s3.go
+++ b/fetch/datablobstorage/s3.go
@@ -14,7 +14,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/cockroachdb/molt/dbtable"
+	"github.com/cockroachdb/molt/testutils"
 	"github.com/rs/zerolog"
 )
 
@@ -113,6 +115,7 @@ func (s *s3Store) CreateFromReader(
 	iteration int,
 	fileExt string,
 	numRows chan int,
+	testingKnobs testutils.FetchTestingKnobs,
 ) (Resource, error) {
 	key := fmt.Sprintf("%s/part_%08d.%s", table.SafeString(), iteration, fileExt)
 	if s.bucketPath != "" {
@@ -120,8 +123,19 @@ func (s *s3Store) CreateFromReader(
 	}
 
 	s.logger.Debug().Str("file", key).Msgf("creating new file")
-	if _, err := s3manager.NewUploader(s.session).UploadWithContext(ctx, &s3manager.UploadInput{
-		Bucket: aws.String(s.bucket),
+
+	bucketName := s.bucket
+
+	var uploader s3manageriface.UploaderAPI
+
+	if testingKnobs.FailedWriteToBucket.FailedAfterReadFromPipe {
+		uploader = &s3UploaderMock{}
+	} else {
+		uploader = s3manager.NewUploader(s.session)
+	}
+
+	if _, err := uploader.UploadWithContext(ctx, &s3manager.UploadInput{
+		Bucket: aws.String(bucketName),
 		Key:    aws.String(key),
 		Body:   r,
 	}); err != nil {

--- a/fetch/datablobstorage/s3_testutils.go
+++ b/fetch/datablobstorage/s3_testutils.go
@@ -1,0 +1,28 @@
+package datablobstorage
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/mock"
+)
+
+type s3UploaderMock struct {
+	s3manageriface.UploaderAPI
+	mock.Mock
+}
+
+const AWSUploadFileMockErrMsg = "mocked error for uploading file for aws"
+
+func (s *s3UploaderMock) Upload(
+	input *s3manager.UploadInput, f ...func(*s3manager.Uploader),
+) (*s3manager.UploadOutput, error) {
+	return nil, errors.Newf(AWSUploadFileMockErrMsg)
+}
+
+func (s *s3UploaderMock) UploadWithContext(
+	context aws.Context, input *s3manager.UploadInput, f ...func(*s3manager.Uploader),
+) (*s3manager.UploadOutput, error) {
+	return nil, errors.Newf(AWSUploadFileMockErrMsg)
+}

--- a/fetch/export_table.go
+++ b/fetch/export_table.go
@@ -90,7 +90,7 @@ func exportTable(
 		resourceWG.Go(func() error {
 			itNum++
 			if err := func() error {
-				resource, err := datasource.CreateFromReader(ctx, forwardRead, table, itNum, importFileExt, numRowsCh)
+				resource, err := datasource.CreateFromReader(ctx, forwardRead, table, itNum, importFileExt, numRowsCh, testingKnobs)
 				if err != nil {
 					return err
 				}

--- a/fetch/export_table.go
+++ b/fetch/export_table.go
@@ -76,7 +76,7 @@ func exportTable(
 	itNum := 0
 	// Errors must be buffered, as pipe can exit without taking the error channel.
 	writerErrCh := make(chan error, 1)
-	pipe := newCSVPipe(sqlRead, logger, cfg.FlushSize, cfg.FlushRows, func() io.WriteCloser {
+	pipe := newCSVPipe(sqlRead, logger, cfg.FlushSize, cfg.FlushRows, func(numRowsCh chan int) io.WriteCloser {
 		resourceWG.Wait()
 		forwardRead, forwardWrite := io.Pipe()
 		wrappedWriter := getWriter(forwardWrite, cfg.Compression)
@@ -85,7 +85,7 @@ func exportTable(
 			defer resourceWG.Done()
 			itNum++
 			if err := func() error {
-				resource, err := datasource.CreateFromReader(ctx, forwardRead, table, itNum, importFileExt)
+				resource, err := datasource.CreateFromReader(ctx, forwardRead, table, itNum, importFileExt, numRowsCh)
 				if err != nil {
 					return err
 				}

--- a/fetch/export_table_test.go
+++ b/fetch/export_table_test.go
@@ -1,0 +1,238 @@
+package fetch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/molt/dbconn"
+	"github.com/cockroachdb/molt/fetch/datablobstorage"
+	"github.com/cockroachdb/molt/fetch/dataexport"
+	"github.com/cockroachdb/molt/testutils"
+	"github.com/cockroachdb/molt/verify/dbverify"
+	"github.com/cockroachdb/molt/verify/tableverify"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	bucketForTest = `migrations-fetch-ci-test`
+	pathInBucket  = `failed-export`
+
+	localPathForTest = `/tmp/failedexport`
+)
+
+func genDataStore(
+	ctx context.Context, logger zerolog.Logger, storageType string, conns dbconn.OrderedConns,
+) (datablobstorage.Store, error) {
+	var datastorePayload any
+	switch storageType {
+	case "gcp":
+		datastorePayload = &datablobstorage.GCPPayload{
+			GCPBucket:  bucketForTest,
+			BucketPath: pathInBucket,
+		}
+	case "aws":
+		datastorePayload = &datablobstorage.S3Payload{
+			S3Bucket:   bucketForTest,
+			BucketPath: pathInBucket,
+			Region:     "us-east-1",
+		}
+	case "local":
+		localStoreListenAddr, localStoreCrdbAccessAddr := testutils.GetLocalStoreAddrs("crdb", "4541")
+		datastorePayload = &datablobstorage.LocalPathPayload{
+			LocalPath:               localPathForTest,
+			LocalPathListenAddr:     localStoreListenAddr,
+			LocalPathCRDBAccessAddr: localStoreCrdbAccessAddr,
+		}
+	case "directcopy":
+		datastorePayload = &datablobstorage.DirectCopyPayload{
+			TargetConnForCopy: conns[1].(*dbconn.PGConn).Conn,
+		}
+	default:
+		return nil, errors.Newf("unknown storage type: %s", storageType)
+	}
+
+	return datablobstorage.GenerateDatastore(ctx, datastorePayload, logger, true /* TestFailedWriteToBucket */)
+}
+
+func TestFailedWriteToStore(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(os.Stderr)
+	const (
+		dbName     = "failed_fetch_export_table"
+		tableName  = "testfailedexport"
+		schemaName = "public"
+
+		createTableQuery        = `CREATE TABLE testfailedexport (x int PRIMARY KEY)`
+		insertTableQueryPattern = `INSERT INTO testfailedexport VALUES (%d)`
+	)
+
+	for _, storageType := range []struct {
+		name        string
+		expectError string
+	}{
+		{
+			name:        "gcp",
+			expectError: datablobstorage.GCPWriterMockErrMsg,
+		},
+		{
+			name:        "aws",
+			expectError: datablobstorage.AWSUploadFileMockErrMsg,
+		},
+		{
+			name:        "local",
+			expectError: datablobstorage.LocalWriterMockErrMsg,
+		},
+		{
+			name:        "directcopy",
+			expectError: datablobstorage.DirectCopyWriterMockErrMsg,
+		},
+	} {
+		t.Run(storageType.name, func(t *testing.T) {
+			type namedTb struct {
+				testutils.FetchTestingKnobs
+				decription string
+			}
+
+			tbs := []namedTb{
+				{
+					decription: "after read from pipe",
+					FetchTestingKnobs: testutils.FetchTestingKnobs{
+						FailedWriteToBucket: testutils.FailedWriteToBucketKnob{
+							FailedAfterReadFromPipe: true,
+						},
+					},
+				},
+			}
+
+			if storageType.name == "local" || storageType.name == "directcopy" {
+				tbs = append(tbs, namedTb{
+					decription: "before read from pipe",
+					FetchTestingKnobs: testutils.FetchTestingKnobs{
+						FailedWriteToBucket: testutils.FailedWriteToBucketKnob{
+							FailedBeforeReadFromPipe: true,
+						},
+					},
+				})
+			}
+
+			for _, tb := range tbs {
+				t.Run(tb.decription, func(t *testing.T) {
+					for _, tc := range []struct {
+						description  string
+						tableRows    int
+						rowBatchSize int
+						flushRows    int
+						noError      bool
+					}{
+						{
+							description:  "empty table",
+							tableRows:    0,
+							rowBatchSize: 10,
+							flushRows:    10,
+							noError:      true,
+						},
+						{
+							description:  "one row table",
+							tableRows:    1,
+							rowBatchSize: 10,
+							flushRows:    10,
+						},
+						{
+							description:  "multi batch export",
+							tableRows:    20,
+							rowBatchSize: 3,
+							flushRows:    3,
+						},
+					} {
+						t.Run(tc.description, func(t *testing.T) {
+
+							var conns dbconn.OrderedConns
+							var err error
+							conns[0], err = dbconn.TestOnlyCleanDatabase(ctx, "source", testutils.MySQLConnStr(), dbName)
+							require.NoError(t, err)
+							conns[1], err = dbconn.TestOnlyCleanDatabase(ctx, "target", testutils.CRDBConnStr(), dbName)
+							require.NoError(t, err)
+
+							// Check the 2 dbs are up.
+							for _, c := range conns {
+								_, err := testutils.ExecConnQuery(ctx, "SELECT 1", c)
+								require.NoError(t, err)
+							}
+
+							defer func() {
+								require.NoError(t, conns[0].Close(ctx))
+								require.NoError(t, conns[1].Close(ctx))
+							}()
+
+							// Create the table in the both databases.
+							for _, conn := range conns {
+								_, err := testutils.ExecConnQuery(ctx, createTableQuery, conn)
+								require.NoError(t, err)
+							}
+
+							// Insert rows only on the source database table.
+							for d := 1; d <= tc.tableRows; d++ {
+								_, err := testutils.ExecConnQuery(ctx, fmt.Sprintf(insertTableQueryPattern, d), conns[0])
+								require.NoError(t, err)
+							}
+
+							// Preparation for the fetch.exportTable function.
+							fetchCfg := Config{
+								FlushRows: tc.flushRows,
+								Cleanup:   false,
+								ExportSettings: dataexport.Settings{
+									RowBatchSize: tc.rowBatchSize,
+								},
+							}
+
+							dbTables, err := dbverify.Verify(ctx, conns)
+							require.NoError(t, err)
+							dbTables, err = dbverify.FilterResult(dbverify.FilterConfig{
+								SchemaFilter: schemaName,
+								TableFilter:  tableName,
+							}, dbTables)
+
+							require.NoError(t, err)
+
+							tables, err := tableverify.VerifyCommonTables(ctx, conns, dbTables.Verified)
+							require.NoError(t, err)
+							require.Equal(t, 1, len(tables))
+							verifiedTable := tables[0].VerifiedTable
+
+							sqlSrc, err := dataexport.InferExportSource(ctx, fetchCfg.ExportSettings, conns[0])
+							require.NoError(t, err)
+
+							dataSrc, err := genDataStore(ctx, logger, storageType.name, conns)
+							require.NoError(t, err)
+
+							require.NoError(t, err)
+
+							_, err = exportTable(
+								ctx,
+								fetchCfg,
+								logger,
+								sqlSrc,
+								dataSrc,
+								verifiedTable,
+								tb.FetchTestingKnobs,
+							)
+
+							if tc.noError {
+								require.NoError(t, err)
+							} else {
+								require.ErrorContains(t, err, storageType.expectError)
+							}
+
+							t.Logf("test passed!")
+						})
+
+					}
+				})
+			}
+		})
+	}
+}

--- a/testutils/knobs.go
+++ b/testutils/knobs.go
@@ -3,4 +3,11 @@ package testutils
 type FetchTestingKnobs struct {
 	// Used to simulate testing when the CSV input file is wrong.
 	TriggerCorruptCSVFile bool
+
+	FailedWriteToBucket FailedWriteToBucketKnob
+}
+
+type FailedWriteToBucketKnob struct {
+	FailedBeforeReadFromPipe bool
+	FailedAfterReadFromPipe  bool
 }

--- a/testutils/local_store.go
+++ b/testutils/local_store.go
@@ -1,0 +1,59 @@
+package testutils
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func GetLocalStoreAddrs(
+	dialect string, port string,
+) (localStoreListenAddr string, localStoreCrdbAccessAddr string) {
+
+	const darwinLocalhostEndpoint = "host.docker.internal"
+	const linuxLocalhostEndpoint = "172.17.0.1"
+	const defaultLocalStorageServerPort = "4040"
+
+	if port == "" {
+		port = defaultLocalStorageServerPort
+	}
+
+	// Resources:
+	// https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal
+	// https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+	// In the CI, the databases are all spin up in docker-compose,
+	// which not necessarily share the network with the host.
+	// When importing the data to the target database,
+	// it requires the database reaches the local storage server
+	// (spun up on host network) from the container (i.e. from
+	// the container's network). According to the 2 links
+	// above, the `localhost` on the host network is accessible
+	// via different endpoint based on the operating system:
+	// - Linux, Windows: 172.17.0.1
+	// - MacOS: host.docker.internal
+	switch runtime.GOOS {
+	case "darwin":
+		localStoreListenAddr = fmt.Sprintf("localhost:%s", port)
+		localStoreCrdbAccessAddr = fmt.Sprintf("%s:%s", darwinLocalhostEndpoint, port)
+	default:
+		switch dialect {
+		case "crdb":
+			// Here the target db is cockroachdbtartget in .github/docker-compose.yaml,
+			// which cannot be spun up on the host network (with ` network_mode: host`).
+			// The reason is the docker image for crdb only allows listen-addr to be
+			// localhost:26257, which will conflict with the `cockroachdb` container.
+			// We thus has to let cockroachdbtartget lives in its own network and port-forward.
+			// In this case in Linux, the host's localhost can only be accessed via `172.17.0.1`
+			// from the container's network.
+			localStoreListenAddr = fmt.Sprintf("%s:%s", linuxLocalhostEndpoint, port)
+		case "pg", "mysql":
+			// Here the target db is cockroachdb in .github/docker-compose.yaml,
+			// which is directly spun up on the host network (with ` network_mode: host`).
+			// In Linux case, it can directly access the host server via localhost.
+			localStoreListenAddr = fmt.Sprintf("localhost:%s", port)
+		default:
+			panic(fmt.Sprintf("unknown dialect: %s", dialect))
+		}
+		localStoreCrdbAccessAddr = localStoreListenAddr
+	}
+	return localStoreListenAddr, localStoreCrdbAccessAddr
+}


### PR DESCRIPTION
## fetch: Add row count per file to blob resource 
(Authored by @Jeremyyang920)

This commit adds a row count field to ever storage resource. The reason for this is mainly for progress tracking but more specfically for the IMPORT use case where we are not able to know the number of rows imported. We now have this information since each resource has its own file count.

Release note: None

----

## fetch: fix deadlock when failed to upload to blob resource

Previous, if error happens when writing result to the storage (gcp/aws/local),
the error won't be properly propagated back to the main routine in exportTable(),
causing the main routine to hang.

This patch is to fix it so that the main process exits in this case.

Context:

- https://cockroachlabs.slack.com/archives/C04TQ67V1JL/p1705445765473889
- https://github.com/cockroachdb/molt/pull/114#discussion_r1453968635

Release note (bug fix): resolve deadlock when failed to upload csv to the data
blob storage.

