### PR TITLE
fetch: integrate continuation with fetch uploaded resources and exception logs

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -2,6 +2,7 @@ package fetch
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/molt/cmd/internal/cmdutil"
@@ -12,6 +13,7 @@ import (
 	"github.com/cockroachdb/molt/fetch/fetchmetrics"
 	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/cockroachdb/molt/testutils"
+	"github.com/cockroachdb/molt/utils"
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag/v2"
 )
@@ -46,6 +48,12 @@ func Command() *cobra.Command {
 			if err := cmdutil.CheckFlagDependency(cmd, continuationToken, []string{continuationFileName}); err != nil {
 				return err
 			}
+
+			// Ensure the continuation-file-name matches the file pattern.
+			if strings.TrimSpace(cfg.ContinuationFileName) != "" && !utils.MatchesFileConvention(cfg.ContinuationFileName) {
+				return errors.Newf(`continuation file name "%s" doesn't match the file convention "%s"`, cfg.ContinuationFileName, utils.FileConventionRegex.String())
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/fetch/datablobstorage/gcp.go
+++ b/fetch/datablobstorage/gcp.go
@@ -9,6 +9,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/testutils"
+	"github.com/cockroachdb/molt/utils"
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"github.com/rs/zerolog"
 	"golang.org/x/oauth2/google"
@@ -131,9 +132,11 @@ func listFromContinuationPointGCP(
 			}
 			return nil, err
 		} else {
-			resources = append(resources, &gcpResource{
-				key: attrs.Name,
-			})
+			if utils.MatchesFileConvention(attrs.Name) {
+				resources = append(resources, &gcpResource{
+					key: attrs.Name,
+				})
+			}
 		}
 	}
 }

--- a/fetch/datablobstorage/local.go
+++ b/fetch/datablobstorage/local.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/testutils"
+	"github.com/cockroachdb/molt/utils"
 	"github.com/rs/zerolog"
 )
 
@@ -140,7 +141,7 @@ func (l *localStore) ListFromContinuationPoint(
 
 	resources := []Resource{}
 	for _, f := range files {
-		if f.Name() >= fileName {
+		if f.Name() >= fileName && utils.MatchesFileConvention(f.Name()) {
 			p := path.Join(baseDir, f.Name())
 			resources = append(resources, &localResource{
 				path:  p,

--- a/fetch/datablobstorage/s3.go
+++ b/fetch/datablobstorage/s3.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/testutils"
+	"github.com/cockroachdb/molt/utils"
 	"github.com/rs/zerolog"
 )
 
@@ -191,7 +192,7 @@ func listFromContinuationPointAWS(
 		// eg. If key = fetch/public.inventory/part_00000004.tar.gz,
 		// fetch/public.inventory/part_00000005.tar.gz is >= to key meaning,
 		// it is a file we need to include.
-		if aws.StringValue(obj.Key) >= key {
+		if aws.StringValue(obj.Key) >= key && utils.MatchesFileConvention(aws.StringValue(obj.Key)) {
 			resources = append(resources, &s3Resource{
 				key:     aws.StringValue(obj.Key),
 				session: s3Store.session,

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -292,6 +292,7 @@ func fetchTable(
 				return
 			}
 
+			logger.Info().Msg("cleaning up resources created during fetch run")
 			for _, r := range e.Resources {
 				if r == nil {
 					continue

--- a/fetch/status/exceptions.go
+++ b/fetch/status/exceptions.go
@@ -199,6 +199,10 @@ func MaybeReportException(
 		return errors.CombineErrors(inputErr, err)
 	}
 
+	logger.Info().
+		Str("table", fmt.Sprintf("%s.%s", table.Schema.String(), table.Table.String())).
+		Str("continuation_token", exceptionLog.ID.String()).Msg("created continuation token")
+
 	return inputErr
 }
 

--- a/fetch/testdata/pg/continuation.ddt
+++ b/fetch/testdata/pg/continuation.ddt
@@ -1,0 +1,244 @@
+# Testing for duplicate key errors.
+exec all
+CREATE TABLE tbl1(id INT PRIMARY KEY, t TEXT)
+----
+[source] CREATE TABLE
+[target] CREATE TABLE
+
+exec all
+CREATE TABLE tbl2(id INT PRIMARY KEY, t TEXT)
+----
+[source] CREATE TABLE
+[target] CREATE TABLE
+
+exec all
+INSERT INTO tbl1 VALUES (11, 'aaa'), (22, 'bb b'), (33, 'ééé'), (44, '🫡🫡🫡'), (55, '娜娜'), (66, 'Лукас'), (77, 'ルカス')
+----
+[source] INSERT 0 7
+[target] INSERT 0 7
+
+exec all
+INSERT INTO tbl2 VALUES (00, 'aaa'), (55, 'bb b'), (66, 'ééé'), (77, '🫡🫡🫡'), (88, '娜娜'), (1010, 'Лукас'), (1212, 'ルカス')
+----
+[source] INSERT 0 7
+[target] INSERT 0 7
+
+query all
+SELECT * FROM tbl1
+----
+[source]:
+id	t
+11	aaa
+22	bb b
+33	ééé
+44	🫡🫡🫡
+55	娜娜
+66	Лукас
+77	ルカス
+tag: SELECT 7
+[target]:
+id	t
+11	aaa
+22	bb b
+33	ééé
+44	🫡🫡🫡
+55	娜娜
+66	Лукас
+77	ルカス
+tag: SELECT 7
+
+query all
+SELECT * FROM tbl2
+----
+[source]:
+id	t
+0	aaa
+55	bb b
+66	ééé
+77	🫡🫡🫡
+88	娜娜
+1010	Лукас
+1212	ルカス
+tag: SELECT 7
+[target]:
+id	t
+0	aaa
+55	bb b
+66	ééé
+77	🫡🫡🫡
+88	娜娜
+1010	Лукас
+1212	ルカス
+tag: SELECT 7
+
+# Force exception log.
+fetch live notruncate expect-error suppress-error store-dir=continuation-test
+----
+
+
+# Create new fetch that has an ID that we can control so we can control args passed in later.
+exec target
+INSERT INTO _molt_fetch_status (id, name, source_dialect) VALUES('d44762e5-6f70-43f8-8e15-58b4de10a007', 'dummy_run', 'PostgreSQL') RETURNING id
+----
+[target] INSERT 0 1
+
+# Make it so that the exception id is deterministic for future steps.
+exec target
+UPDATE _molt_fetch_exception SET fetch_id = 'd44762e5-6f70-43f8-8e15-58b4de10a007' WHERE table_name LIKE 'tbl%'
+----
+[target] UPDATE 2
+
+# Ensure that the fetch_id stays consistent between test recordings.
+query target
+SELECT fetch_id, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
+----
+[target]:
+fetch_id	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	tbl2	duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists.	23505	part_00000001.csv	data_load
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	tbl1	duplicate key value violates unique constraint "tbl1_pkey"; Key (id)=(11) already exists.	23505	part_00000001.csv	data_load
+tag: SELECT 2
+
+# Clean up the target table and verify that it's cleaned.
+exec target
+TRUNCATE tbl1
+----
+[target] TRUNCATE
+
+exec target
+TRUNCATE tbl2
+----
+[target] TRUNCATE
+
+query all
+SELECT * FROM tbl1
+----
+[source]:
+id	t
+11	aaa
+22	bb b
+33	ééé
+44	🫡🫡🫡
+55	娜娜
+66	Лукас
+77	ルカス
+tag: SELECT 7
+[target]:
+id	t
+tag: SELECT 0
+
+# Run fetch with continue and verify that it loads the data properly.
+fetch live notruncate store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007
+----
+
+# Verify that the continuation worked and that data for both tables is loaded properly.
+query all
+SELECT * FROM tbl1
+----
+[source]:
+id	t
+11	aaa
+22	bb b
+33	ééé
+44	🫡🫡🫡
+55	娜娜
+66	Лукас
+77	ルカス
+tag: SELECT 7
+[target]:
+id	t
+11	aaa
+22	bb b
+33	ééé
+44	🫡🫡🫡
+55	娜娜
+66	Лукас
+77	ルカス
+tag: SELECT 7
+
+query all
+SELECT * FROM tbl2
+----
+[source]:
+id	t
+0	aaa
+55	bb b
+66	ééé
+77	🫡🫡🫡
+88	娜娜
+1010	Лукас
+1212	ルカス
+tag: SELECT 7
+[target]:
+id	t
+0	aaa
+55	bb b
+66	ééé
+77	🫡🫡🫡
+88	娜娜
+1010	Лукас
+1212	ルカス
+tag: SELECT 7
+
+# Cleanup both tables on the target.
+exec target
+TRUNCATE tbl1
+----
+[target] TRUNCATE
+
+exec target
+TRUNCATE tbl2
+----
+[target] TRUNCATE
+
+# Update the entry so we can continue from a known token we control.
+exec target
+UPDATE _molt_fetch_exception SET id = '011762e5-6f70-43f8-8e15-58b4de10a007' WHERE table_name LIKE 'tbl2'
+----
+[target] UPDATE 1
+
+# Run fetch again on only one table.
+fetch live notruncate cleanup-dir store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007 continuation-token=011762e5-6f70-43f8-8e15-58b4de10a007
+----
+
+# Verify that the continuation worked and that data for table 2 is loaded properly.
+# Table 1 should not have any data loaded.
+query all
+SELECT * FROM tbl1
+----
+[source]:
+id	t
+11	aaa
+22	bb b
+33	ééé
+44	🫡🫡🫡
+55	娜娜
+66	Лукас
+77	ルカス
+tag: SELECT 7
+[target]:
+id	t
+tag: SELECT 0
+
+query all
+SELECT * FROM tbl2
+----
+[source]:
+id	t
+0	aaa
+55	bb b
+66	ééé
+77	🫡🫡🫡
+88	娜娜
+1010	Лукас
+1212	ルカス
+tag: SELECT 7
+[target]:
+id	t
+0	aaa
+55	bb b
+66	ééé
+77	🫡🫡🫡
+88	娜娜
+1010	Лукас
+1212	ルカス
+tag: SELECT 7

--- a/utils/formatting.go
+++ b/utils/formatting.go
@@ -2,10 +2,17 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 )
 
 func SchemaTableString(schema, table tree.Name) string {
 	return fmt.Sprintf("%s.%s", string(schema), string(table))
+}
+
+var FileConventionRegex = regexp.MustCompile(`part_[\d+]{8}(\.csv|\.tar\.gz)`)
+
+func MatchesFileConvention(fileName string) bool {
+	return FileConventionRegex.MatchString(fileName)
 }

--- a/utils/formatting_test.go
+++ b/utils/formatting_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchesFileConvention(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		want     bool
+	}{
+		{
+			name:     "matching csv file",
+			fileName: "part_00000004.csv",
+			want:     true,
+		},
+		{
+			name:     "matching gzip file",
+			fileName: "part_00000004.tar.gz",
+			want:     true,
+		},
+		{
+			name:     "non-matching csv file because wrong number of digits",
+			fileName: "part_0000004.tar.gz",
+			want:     false,
+		},
+		{
+			name:     "non-matching file but similar",
+			fileName: "part_djdkfjkd.tar.gz",
+			want:     false,
+		},
+		{
+			name:     "non-matching file completely different",
+			fileName: "pakl;sdjf;alksdjf;alksdf",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := MatchesFileConvention(tt.fileName)
+			require.Equal(t, tt.want, actual)
+		})
+	}
+}


### PR DESCRIPTION


Added in logic for the import/copy only mode that skips the export phase if fetch id or continuation token is passed in. Also integrated with the logic to continue from a certain file point.

Resolves: CC-26910
Release Note: None

- [x] Manual test
- [x] Log out fetch ID and continuation token
- [x] Automated tests