### PR TITLE
fetch: fix continue logging so it only logs on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,9 @@ sync_hooks:
 
 rewrite_fetch_tests:
 	go test -v -run ^TestDataDriven github.com/cockroachdb/molt/fetch --rewrite
+
+run_e2e_tests:
+	go test -timeout 100s -run TestDataDriven github.com/cockroachdb/molt/e2e -e2e-enabled
+
+rewrite_e2e_tests:
+	go test -timeout 100s -run TestDataDriven github.com/cockroachdb/molt/e2e -e2e-enabled --rewrite

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -148,9 +148,12 @@ func Fetch(
 
 	// Wait until all the verification portions are completed first before deferring this.
 	// If verify fails, we don't need to report fetch_id.
+	// We only want to log out if the fetch fails.
 	defer func() {
-		logger.Info().
-			Str("fetch_id", fetchStatus.ID.String()).Msg("continue from this fetch ID")
+		if retErr != nil {
+			logger.Info().
+				Str("fetch_id", fetchStatus.ID.String()).Msg("continue from this fetch ID")
+		}
 	}()
 
 	numTables := len(tables)


### PR DESCRIPTION
Success
```
{"level":"info","type":"summary","net_duration_ms":1909.038584,"net_duration":"000h 00m 01s","import_duration_ms":1550.864625,"import_duration":"000h 00m 01s","export_duration_ms":354.458375,"export_duration":"000h 00m 00s","num_rows":200000,"cdc_cursor":"0/3F5ABD0","time":"2024-02-07T12:06:12-05:00","message":"data import on target for table complete"}
{"level":"info","type":"summary","fetch_id":"f6cd1d37-98a6-4620-9188-671a1e1ced7d","num_tables":1,"tables":["public.employees"],"cdc_cursor":"0/3F5ABD0","net_duration_ms":1946.456708,"net_duration":"000h 00m 01s","time":"2024-02-07T12:06:12-05:00","message":"fetch complete"}
```

Failure
```
{"level":"info","fetch_id":"011fe845-117d-4533-bf6b-5e8506da355a","time":"2024-02-07T12:06:47-05:00","message":"continue from this fetch ID"}
Error: ERROR: duplicate key value violates unique constraint "employees_pkey" (SQLSTATE 23505)
Usage:
```

Release Note: None