### PR TITLE
fetch: added numrows metadata to file upload for GCP

### DIFF
--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -16,6 +16,8 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+const numRowsKey = "numRows"
+
 type Store interface {
 	// CreateFromReader is responsible for the creation of the individual
 	// CSVs from the data export process. It will create the file and upload

--- a/fetch/datablobstorage/gcp_test.go
+++ b/fetch/datablobstorage/gcp_test.go
@@ -49,11 +49,11 @@ func TestListFromContinuationPointGCP(t *testing.T) {
 		Return(&gcpObjectITMock{
 			i: 0,
 			next: []storage.ObjectAttrs{
-				{Name: "part_00000004.tar.gz"},
-				{Name: "part_00000005.tar.gz"},
-				{Name: "part_00000006.tar.gz"},
-				{Name: "part_00000007.tar.gz"},
-				{Name: "part_00000008.tar.gz"},
+				{Name: "part_00000004.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
+				{Name: "part_00000005.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
+				{Name: "part_00000006.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
+				{Name: "part_00000007.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
+				{Name: "part_00000008.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
 			},
 		})
 
@@ -63,7 +63,7 @@ func TestListFromContinuationPointGCP(t *testing.T) {
 			JSON: []byte(`{"a":b}`),
 		},
 	}
-	resources, err := listFromContinuationPointGCP(ctx, gcpClient, "part_00000004.tar.gz", "public.inventory", gcpStore.bucket)
+	resources, err := listFromContinuationPointGCP(ctx, gcpClient, "part_00000004.tar.gz", "public.inventory", gcpStore.bucket, nil /* gcpStore */)
 	require.NoError(t, err)
 	require.Len(t, resources, 5)
 }


### PR DESCRIPTION
We want to track the number of rows per file so we can know how many rows have been imported as we do the import. Additionally, fixed a couple bugs: potential deadlock, panic because of invalid store passed in, etc.

Resolves: CC-27046
Release Note: None

Runs properly (verified it logs out the number of rows per resource)
```
&{0x140004d8d80 public.employees/part_00000001.tar.gz 200000}
```

```
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . fetch \             
  --source 'postgres://postgres:postgres@localhost:5432/molt?sslmode=disable' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' \
  --table-filter 'employees' \
  --gcp-bucket migrations-fetch-ci-test --fetch-id 6c81abeb-187a-41f8-ada6-c29c66684b36
{"level":"info","time":"2024-02-07T15:13:48-05:00","message":"default compression to GZIP"}
{"level":"info","time":"2024-02-07T15:13:48-05:00","message":"checking database details"}
{"level":"info","source_table":"public.employees","target_table":"public.employees","time":"2024-02-07T15:13:48-05:00","message":"found matching table"}
{"level":"info","time":"2024-02-07T15:13:48-05:00","message":"verifying common tables"}
{"level":"info","time":"2024-02-07T15:13:48-05:00","message":"establishing snapshot"}
{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/3F3E068","time":"2024-02-07T15:13:48-05:00","message":"starting fetch"}
{"level":"info","time":"2024-02-07T15:13:48-05:00","message":"data extraction phase starting"}
{"level":"warn","time":"2024-02-07T15:13:48-05:00","message":"skipping export for table public.employees due to running in import-copy only mode"}
{"level":"info","type":"summary","num_rows":0,"export_duration_ms":0,"export_duration":"000h 00m 00s","time":"2024-02-07T15:13:49-05:00","message":"data extraction from source complete"}
{"level":"info","time":"2024-02-07T15:13:49-05:00","message":"starting data import on target"}
&{0x140004d8d80 public.employees/part_00000001.tar.gz 200000}
{"level":"info","type":"summary","net_duration_ms":7985.451458,"net_duration":"000h 00m 07s","import_duration_ms":7339.223542,"import_duration":"000h 00m 07s","export_duration_ms":0,"export_duration":"000h 00m 00s","num_rows":0,"cdc_cursor":"0/3F3E068","time":"2024-02-07T15:13:56-05:00","message":"data import on target for table complete"}
{"level":"info","type":"summary","fetch_id":"c15c0101-0a64-4edc-bf92-076fd27720fe","num_tables":1,"tables":["public.employees"],"cdc_cursor":"0/3F3E068","net_duration_ms":8028.664125,"net_duration":"000h 00m 08s","time":"2024-02-07T15:13:56-05:00","message":"fetch complete"}
```