### PR TITLE
fetch: added in upload metadata for S3

### DIFF
--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -16,8 +16,6 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-const numRowsKey = "numRows"
-
 type Store interface {
 	// CreateFromReader is responsible for the creation of the individual
 	// CSVs from the data export process. It will create the file and upload

--- a/fetch/datablobstorage/gcp.go
+++ b/fetch/datablobstorage/gcp.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+const numRowsKeyGCP = "numRows"
+
 type gcpStore struct {
 	logger     zerolog.Logger
 	bucket     string
@@ -103,7 +105,7 @@ func (s *gcpStore) CreateFromReader(
 	// Update the object to set the metadata.
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		Metadata: map[string]string{
-			numRowsKey: fmt.Sprintf("%d", rows),
+			numRowsKeyGCP: fmt.Sprintf("%d", rows),
 		},
 	}
 
@@ -147,9 +149,9 @@ func listFromContinuationPointGCP(
 			return nil, err
 		} else {
 			if utils.MatchesFileConvention(attrs.Name) {
-				mdNumRows, ok := attrs.Metadata[numRowsKey]
+				mdNumRows, ok := attrs.Metadata[numRowsKeyGCP]
 				if !ok {
-					gcpStore.logger.Error().Msgf("failed to find metadata for key %s", numRowsKey)
+					gcpStore.logger.Error().Msgf("failed to find metadata for key %s", numRowsKeyGCP)
 				}
 
 				numRows, err := strconv.Atoi(mdNumRows)

--- a/fetch/datablobstorage/gcp_test.go
+++ b/fetch/datablobstorage/gcp_test.go
@@ -49,11 +49,11 @@ func TestListFromContinuationPointGCP(t *testing.T) {
 		Return(&gcpObjectITMock{
 			i: 0,
 			next: []storage.ObjectAttrs{
-				{Name: "part_00000004.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
-				{Name: "part_00000005.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
-				{Name: "part_00000006.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
-				{Name: "part_00000007.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
-				{Name: "part_00000008.tar.gz", Metadata: map[string]string{numRowsKey: "10"}},
+				{Name: "part_00000004.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
+				{Name: "part_00000005.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
+				{Name: "part_00000006.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
+				{Name: "part_00000007.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
+				{Name: "part_00000008.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
 			},
 		})
 

--- a/fetch/datablobstorage/s3_test.go
+++ b/fetch/datablobstorage/s3_test.go
@@ -57,19 +57,25 @@ func TestS3Resource_ImportURL(t *testing.T) {
 
 type mockS3Client struct {
 	s3iface.S3API
-	resp *s3.ListObjectsV2Output
-	err  error
+	listResp *s3.ListObjectsV2Output
+	getResp  *s3.GetObjectOutput
+	err      error
 }
 
 func (m *mockS3Client) ListObjectsV2WithContext(
 	ctx context.Context, params *s3.ListObjectsV2Input, opts ...request.Option,
 ) (*s3.ListObjectsV2Output, error) {
-	return m.resp, m.err
+	return m.listResp, m.err
+}
+
+func (m *mockS3Client) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	return m.getResp, m.err
 }
 
 func TestListFromContinuationPointAWS(t *testing.T) {
+	rows := "10"
 	s3CLI := &mockS3Client{
-		resp: &s3.ListObjectsV2Output{
+		listResp: &s3.ListObjectsV2Output{
 			Contents: []*s3.Object{
 				{Key: aws.String("part_00000001.tar.gz")},
 				{Key: aws.String("part_00000002.tar.gz")},
@@ -79,6 +85,11 @@ func TestListFromContinuationPointAWS(t *testing.T) {
 				{Key: aws.String("part_00000006.tar.gz")},
 				{Key: aws.String("part_00000007.tar.gz")},
 				{Key: aws.String("part_00000008.tar.gz")},
+			},
+		},
+		getResp: &s3.GetObjectOutput{
+			Metadata: map[string]*string{
+				numRowKeysAWS: &rows,
 			},
 		},
 		err: nil,


### PR DESCRIPTION
Added in concurrency for listing from continuation point so we don't block on our request to get specific metadata details per each file. Also added in the calls to external APIs and the upload metadata line.

Resolves: CC-27046
Release Note: None

Test Results:
```
{"level":"warn","time":"2024-02-07T17:18:07-05:00","message":"skipping export for table public.employees due to running in import-copy only mode"}
map[Numrows:0x14000c352f0]
map[Numrows:0x140008f0110]
map[Numrows:0x140008f0270]
map[Numrows:0x140008f0320]
&{0x140006fd080 0x1400092eff0 public.employees/part_00000001.tar.gz 10} &{0x140006fd080 0x1400092eff0 public.employees/part_00000002.tar.gz 10} &{0x140006fd080 0x1400092eff0 public.employees/part_00000003.tar.gz 10} &{0x140006fd080 0x1400092eff0 public.employees/part_00000004.tar.gz 10}
...
{"level":"info","type":"summary","net_duration_ms":12759.923,"net_duration":"000h 00m 12s","import_duration_ms":12220.382875,"import_duration":"000h 00m 12s","export_duration_ms":0,"export_duration":"000h 00m 00s","num_rows":0,"cdc_cursor":"0/3F3E068","time":"2024-02-07T17:18:20-05:00","message":"data import on target for table complete"}
{"level":"info","type":"summary","fetch_id":"41ca41c4-43e3-4b05-992a-f791e65d5575","num_tables":1,"tables":["public.employees"],"cdc_cursor":"0/3F3E068","net_duration_ms":12807.8045,"net_duration":"000h 00m 12s","time":"2024-02-07T17:18:20-05:00","message":"fetch complete"}
...

root@:26257/defaultdb> SELECT COUNT(*) FROM employees;
  count
----------
  200000
```

TODO:
- [x] Fix panic from this test:

```
func TestListFromContinuationPointAWS(t *testing.T) {
```