### PR TITLE
fetch: fix MaybeFormatFetchID so that it uses the correct format fetch ID in non test mode

### DIFF
--- a/utils/formatting.go
+++ b/utils/formatting.go
@@ -49,5 +49,9 @@ func MaybeFormatCDCCursor(testOnly bool, s string) string {
 
 // MaybeFormatFetchID is to make a deterministic fetch id for test.
 func MaybeFormatFetchID(testOnly bool, s string) string {
+	if !testOnly {
+		return s
+	}
+
 	return "0000000000"
 }


### PR DESCRIPTION

Release Note: None

Test results:
```
{"level":"info","time":"2024-02-08T18:25:30-05:00","message":"starting data import on target"}
{"level":"info","table":"public.employees","continuation_token":"e271639b-e55b-4735-887a-709655e144a0","time":"2024-02-08T18:25:50-05:00","message":"created continuation token"}
{"level":"info","fetch_id":"96b99aff-1538-4e68-a9cd-9c3cec063d46","time":"2024-02-08T18:25:50-05:00","message":"continue from this fetch ID"}
```