### PR TITLE
fetch/datablobstorage: support local files numRows metadata

### DIFF
--- a/docker/cockroach-init/cockroach-init.sql
+++ b/docker/cockroach-init/cockroach-init.sql
@@ -9,3 +9,5 @@ CREATE TABLE employees (
 	salary DECIMAL(8,2),
 	bonus FLOAT4
 );
+
+CREATE TABLE tbl1(id INT PRIMARY KEY, t TEXT);

--- a/docker/pg-init/pg-init.sql
+++ b/docker/pg-init/pg-init.sql
@@ -33,3 +33,7 @@ BEGIN
         i := i + 1;
     END LOOP;
 END $$;
+
+CREATE TABLE tbl1(id INT PRIMARY KEY, t TEXT);
+
+INSERT INTO tbl1 VALUES (1, 'aaa'), (2, 'bb b'), (3, 'ééé'), (4, '🫡🫡🫡'), (5, '娜娜'), (6, 'Лукас'), (7, 'ルカス');

--- a/fetch/copy.go
+++ b/fetch/copy.go
@@ -26,6 +26,7 @@ func Copy(
 	logger zerolog.Logger,
 	table dbtable.VerifiedTable,
 	resources []datablobstorage.Resource,
+	isLocal bool,
 ) (CopyResult, error) {
 	dataLogger := moltlogger.GetDataLogger(logger)
 	ret := CopyResult{
@@ -55,7 +56,7 @@ func Copy(
 			if copyRet, err := conn.PgConn().CopyFrom(
 				ctx,
 				r,
-				dataquery.CopyFrom(table),
+				dataquery.CopyFrom(table, isLocal /*skips header if local */),
 			); err != nil {
 				fileName := path.Base(key)
 				return status.MaybeReportException(ctx, logger, conn, table.Name, err, fileName, status.StageDataLoad)

--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -41,6 +41,7 @@ type Resource interface {
 	ImportURL() (string, error)
 	MarkForCleanup(ctx context.Context) error
 	Reader(ctx context.Context) (io.ReadCloser, error)
+	IsLocal() bool
 }
 
 func getKeyAndPrefix(fileName, bucketPath string, table dbtable.VerifiedTable) (string, string) {

--- a/fetch/datablobstorage/gcp.go
+++ b/fetch/datablobstorage/gcp.go
@@ -220,3 +220,7 @@ func (r *gcpResource) Reader(ctx context.Context) (io.ReadCloser, error) {
 func (r *gcpResource) MarkForCleanup(ctx context.Context) error {
 	return r.store.client.Bucket(r.store.bucket).Object(r.key).Delete(ctx)
 }
+
+func (r *gcpResource) IsLocal() bool {
+	return false
+}

--- a/fetch/datablobstorage/s3.go
+++ b/fetch/datablobstorage/s3.go
@@ -64,6 +64,10 @@ func (s *s3Resource) Rows() int {
 	return s.rows
 }
 
+func (s *s3Resource) IsLocal() bool {
+	return false
+}
+
 func (s *s3Resource) MarkForCleanup(ctx context.Context) error {
 	s.store.batchDelete.Lock()
 	defer s.store.batchDelete.Unlock()

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -364,6 +364,10 @@ func fetchTable(
 			logger.Info().
 				Msgf("starting data import on target")
 
+			isLocal := false
+			if len(e.Resources) > 0 {
+				isLocal = e.Resources[0].IsLocal()
+			}
 			if !cfg.Live {
 				go func() {
 					err := reportImportTableProgress(ctx,
@@ -377,14 +381,13 @@ func fetchTable(
 					}
 				}()
 
-				r, err := importTable(ctx, cfg, targetConn, logger, table.VerifiedTable, e.Resources, testingKnobs)
+				r, err := importTable(ctx, cfg, targetConn, logger, table.VerifiedTable, e.Resources, testingKnobs, isLocal)
 				if err != nil {
 					return err
 				}
-				fetchmetrics.ImportedRows.WithLabelValues(table.SafeString()).Add(float64(e.NumRows))
 				importDuration = utils.MaybeFormatDurationForTest(cfg.TestOnly, r.EndTime.Sub(r.StartTime))
 			} else {
-				r, err := Copy(ctx, targetConn, logger, table.VerifiedTable, e.Resources)
+				r, err := Copy(ctx, targetConn, logger, table.VerifiedTable, e.Resources, isLocal)
 				if err != nil {
 					return err
 				}

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -93,6 +94,7 @@ func TestDataDriven(t *testing.T) {
 						passedInDir := ""
 						cleanup := false
 						continuationToken := ""
+						flushRows := 0
 
 						for _, cmd := range d.CmdArgs {
 							switch cmd.Key {
@@ -114,6 +116,10 @@ func TestDataDriven(t *testing.T) {
 								cleanup = true
 							case "continuation-token":
 								continuationToken = cmd.Vals[0]
+							case "flush-rows":
+								flushRowsAtoi, err := strconv.Atoi(cmd.Vals[0])
+								require.NoError(t, err)
+								flushRows = flushRowsAtoi
 							default:
 								t.Errorf("unknown key %s", cmd.Key)
 							}
@@ -167,6 +173,7 @@ func TestDataDriven(t *testing.T) {
 								FetchID:           fetchId,
 								Cleanup:           cleanup,
 								ContinuationToken: continuationToken,
+								FlushRows:         flushRows,
 							},
 							logger,
 							conns,

--- a/fetch/internal/dataquery/dataquery.go
+++ b/fetch/internal/dataquery/dataquery.go
@@ -59,7 +59,7 @@ func ImportInto(table dbtable.VerifiedTable, locs []string, opts tree.KVOptions)
 	return f.CloseAndGetString(), redacted
 }
 
-func CopyFrom(table dbtable.VerifiedTable) string {
+func CopyFrom(table dbtable.VerifiedTable, skipHeader bool) string {
 	copyFrom := &tree.CopyFrom{
 		Table:   table.MakeTableName(),
 		Columns: table.Columns,
@@ -67,6 +67,8 @@ func CopyFrom(table dbtable.VerifiedTable) string {
 		Options: tree.CopyOptions{
 			CopyFormat: tree.CopyFormatCSV,
 			HasFormat:  true,
+			Header:     skipHeader,
+			HasHeader:  skipHeader,
 		},
 	}
 	f := tree.NewFmtCtx(tree.FmtParsableNumerics)

--- a/fetch/testdata/pg/direct.ddt
+++ b/fetch/testdata/pg/direct.ddt
@@ -74,3 +74,31 @@ id	t
 6	Лукас
 7	ルカス
 tag: SELECT 7
+
+# To test that we can handle multiple batches without hanging.
+fetch direct flush-rows=1
+----
+
+query all
+SELECT * FROM tbl1
+----
+[source]:
+id	t
+1	aaa
+2	bb b
+3	ééé
+4	🫡🫡🫡
+5	娜娜
+6	Лукас
+7	ルカス
+tag: SELECT 7
+[target]:
+id	t
+1	aaa
+2	bb b
+3	ééé
+4	🫡🫡🫡
+5	娜娜
+6	Лукас
+7	ルカス
+tag: SELECT 7


### PR DESCRIPTION
Resolves: CC-27188
Release Note: None

Existing CI passing should be enough to validate this works.

Manually tested too:
```
molt_fetch_overall_duration 1.3976359999999999
# HELP molt_fetch_rows_exported Number of rows that have been exported by table.
# TYPE molt_fetch_rows_exported counter
molt_fetch_rows_exported{table="public.employees"} 200000
# HELP molt_fetch_rows_imported Number of rows that have been imported by table.
# TYPE molt_fetch_rows_imported counter
molt_fetch_rows_imported{table="public.employees"} 200000
```