### PR TITLE
fetch: fix ordering of primary key

### DIFF
--- a/verify/tableverify/query.go
+++ b/verify/tableverify/query.go
@@ -186,15 +186,20 @@ func getPrimaryKey(
 		rows, err := conn.Query(
 			ctx,
 			`
-select
-    a.attname as column_name
-from
-    pg_class t
-    join pg_attribute a on a.attrelid = t.oid
-    join pg_index ix    on t.oid = ix.indrelid AND a.attnum = ANY(ix.indkey)
-    join pg_class i     on i.oid = ix.indexrelid  
-where
-    t.oid = $1 AND indisprimary;
+SELECT
+    a.attname AS column_name
+FROM
+    pg_index i
+JOIN
+    pg_attribute a ON a.attrelid = i.indrelid
+AND
+    a.attnum = ANY(i.indkey)
+WHERE
+    i.indrelid = $1
+AND
+    i.indisprimary
+ORDER BY
+    array_position(i.indkey, a.attnum);
 `,
 			table.OID,
 		)

--- a/verify/testdata/datadriven/mysql/primary_key.ddt
+++ b/verify/testdata/datadriven/mysql/primary_key.ddt
@@ -1,0 +1,39 @@
+# No PRIMARY KEY.
+
+exec source
+CREATE TABLE t_bad (i1 INT4 NOT NULL, i2 INT4 NOT NULL, t TEXT NOT NULL, CONSTRAINT pkey PRIMARY KEY (i2, i1))
+----
+[mysql] 0 rows affected
+
+exec target
+CREATE TABLE t_bad (i1 INT4 NOT NULL, i2 INT4 NOT NULL, t TEXT NOT NULL, CONSTRAINT pkey PRIMARY KEY (i1, i2))
+----
+[crdb] CREATE TABLE
+
+verify
+----
+{"level":"warn","type":"data","table_schema":"public","table_name":"t_bad","mismatch_info":"PRIMARY KEY does not match source of truth (columns and types must match)","message":"mismatching table definition"}
+
+exec all
+DROP TABLE t_bad;
+----
+[mysql] 0 rows affected
+[crdb] DROP TABLE
+
+
+exec all
+CREATE TABLE t_good (i1 INT4 NOT NULL, i2 INT4 NOT NULL, t TEXT NOT NULL, CONSTRAINT pkey PRIMARY KEY (i2, i1))
+----
+[mysql] 0 rows affected
+[crdb] CREATE TABLE
+
+verify
+----
+{"level":"info","message":"starting verify on public.t_good, shard 1/1"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"t_good","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.t_good (shard 1/1)"}
+
+exec all
+DROP TABLE t_good;
+----
+[mysql] 0 rows affected
+[crdb] DROP TABLE

--- a/verify/testdata/datadriven/pg/primary_key.ddt
+++ b/verify/testdata/datadriven/pg/primary_key.ddt
@@ -1,0 +1,39 @@
+# No PRIMARY KEY.
+
+exec source
+CREATE TABLE t_bad (i1 INT4 NOT NULL, i2 INT4 NOT NULL, t TEXT NOT NULL, CONSTRAINT pkey PRIMARY KEY (i2, i1))
+----
+[pg] CREATE TABLE
+
+exec target
+CREATE TABLE t_bad (i1 INT4 NOT NULL, i2 INT4 NOT NULL, t TEXT NOT NULL, CONSTRAINT pkey PRIMARY KEY (i1, i2))
+----
+[crdb] CREATE TABLE
+
+verify
+----
+{"level":"warn","type":"data","table_schema":"public","table_name":"t_bad","mismatch_info":"PRIMARY KEY does not match source of truth (columns and types must match)","message":"mismatching table definition"}
+
+exec all
+DROP TABLE t_bad;
+----
+[pg] DROP TABLE
+[crdb] DROP TABLE
+
+
+exec all
+CREATE TABLE t_good (i1 INT4 NOT NULL, i2 INT4 NOT NULL, t TEXT NOT NULL, CONSTRAINT pkey PRIMARY KEY (i2, i1))
+----
+[pg] CREATE TABLE
+[crdb] CREATE TABLE
+
+verify
+----
+{"level":"info","message":"starting verify on public.t_good, shard 1/1"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"t_good","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.t_good (shard 1/1)"}
+
+exec all
+DROP TABLE t_good;
+----
+[pg] DROP TABLE
+[crdb] DROP TABLE


### PR DESCRIPTION
Previously, in cases where a table in fetch/verify has a compund primary key whose ordering doesn't match that of the order of the columns in the base table, fetch and verify would order the columns incorrectly. This would produce incorrect results in verify, but more importantly, it would make fetch insanely slow. The reason why has to do with how fetch runs export. To avoid issuing a single large query, fetch breaks the export down into batch-sized chunks (the default batch size is 100K rows). To ensure that it knows where it stopped, it leverages the primary key and issues a SELECT <column names> order by <PK columns> limit <batch_size>. Then, it records the PK value at which it left off and issues subsequent SELECT <column names> where PK > <left off value> order by <PK columns> limit <batch_size>.

The problem with not getting the PK ordering right is that instead of leveraging the PK for the query, fetch instead has to sort the entire table each time it issues a query. This is most pronounced in cases where the table being fetched is large. For a 104M table, tests showed that it would take 17 hours to perform the export phase. With the fix to get the PK ordering correct, the export takes 3 minutes.