### PR TITLE
mysqlcov: fix for bits conversion, support time conversion

### DIFF
--- a/mysqlconv/data_type.go
+++ b/mysqlconv/data_type.go
@@ -5,47 +5,47 @@ import (
 	"github.com/lib/pq/oid"
 )
 
-func DataTypeToOID(dataType, columnType string) oid.Oid {
+func DataTypeToOID(dataType, columnType string) (oid.Oid, error) {
 	switch dataType {
 	case "integer", "int", "mediumint":
-		return oid.T_int4
+		return oid.T_int4, nil
 	case "smallint", "tinyint":
-		return oid.T_int2
+		return oid.T_int2, nil
 	case "bigint":
-		return oid.T_int8
+		return oid.T_int8, nil
 	case "decimal", "numeric":
-		return oid.T_numeric
+		return oid.T_numeric, nil
 	case "float":
-		return oid.T_float4
+		return oid.T_float4, nil
 	case "double":
-		return oid.T_float8
+		return oid.T_float8, nil
 	case "bit":
-		return oid.T_varbit
+		return oid.T_varbit, nil
 	case "date":
-		return oid.T_date
+		return oid.T_date, nil
 	case "datetime":
-		return oid.T_timestamp
+		return oid.T_timestamp, nil
 	case "timestamp":
-		return oid.T_timestamptz
+		return oid.T_timestamptz, nil
 	case "time":
-		return oid.T_time
+		return oid.T_time, nil
 	case "char":
-		return oid.T_varchar
+		return oid.T_varchar, nil
 	case "varchar":
-		return oid.T_varchar
+		return oid.T_varchar, nil
 	case "binary":
-		return oid.T_bytea
+		return oid.T_bytea, nil
 	case "varbinary":
-		return oid.T_bytea
+		return oid.T_bytea, nil
 	case "blob", "text", "mediumtext", "longtext":
-		return oid.T_text
+		return oid.T_text, nil
 	case "json":
-		return oid.T_jsonb
+		return oid.T_jsonb, nil
 	case "enum":
-		return oid.T_anyenum
+		return oid.T_anyenum, nil
 	case "set":
-		panic(errors.Newf("enums not yet handled"))
+		return 0, errors.Newf("set not yet handled")
 	default:
-		panic(errors.Newf("unhandled data type %s, column type %s", dataType, columnType))
+		return 0, errors.Newf("unhandled data type %s, column type %s", dataType, columnType)
 	}
 }

--- a/mysqlconv/data_type_test.go
+++ b/mysqlconv/data_type_test.go
@@ -51,7 +51,8 @@ WHERE table_schema = database() AND table_name = ? ORDER BY ORDINAL_POSITION`,
 					var dt string
 					var cn string
 					require.NoError(t, rows.Scan(&cn, &dt, &ct))
-					oid := DataTypeToOID(dt, ct)
+					oid, err := DataTypeToOID(dt, ct)
+					require.NoError(t, err)
 					str := fmt.Sprintf("(non-standard) %d", oid)
 					if typ, ok := types.OidToType[oid]; ok {
 						str = typ.String()

--- a/mysqlconv/datum_converter.go
+++ b/mysqlconv/datum_converter.go
@@ -1,10 +1,13 @@
 package mysqlconv
 
 import (
+	"encoding/binary"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/util/duration"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/util/json"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/molt/parsectx"
@@ -40,6 +43,27 @@ func ConvertRowValue(typMap *pgtype.Map, val []byte, typOID oid.Oid) (tree.Datum
 		v := string(val)
 		ret, _, err := tree.ParseDTimestampTZ(parsectx.ParseContext, v, time.Microsecond)
 		return ret, err
+	case pgtype.TimeOID:
+		// https://dev.mysql.com/doc/refman/8.0/en/time.html
+		// https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html#:~:text=MySQL%20recognizes%20TIME%20values%20in%20these%20formats%3A
+		// From MySQL's doc:
+		// MySQL retrieves and displays TIME values in 'hh:mm:ss' format (or 'hhh:mm:ss' format for large hours values).
+		// TIME values may range from '-838:59:59' to '838:59:59'. The hours part may be so large because the TIME type
+		// can be used not only to represent a time of day (which must be less than 24 hours), but also elapsed time or
+		// a time interval between two events (which may be much greater than 24 hours, or even negative).
+		v := string(val)
+		var ret tree.Datum
+		var err error
+		ret, _, err = tree.ParseDTime(parsectx.ParseContext, v, time.Microsecond)
+		if err == nil {
+			return ret, nil
+		}
+		// If the value cannot be parsed a time datum, try parse it as an interval. See explanation above.
+		ret, err = tree.ParseDInterval(duration.IntervalStyle_SQL_STANDARD, v)
+		if err != nil {
+			return ret, errors.Wrapf(err, "input %q cannot be parsed as time or interval", v)
+		}
+		return ret, nil
 	case pgtype.DateOID:
 		ret, _, err := tree.ParseDDate(parsectx.ParseContext, string(val))
 		return ret, err
@@ -48,7 +72,20 @@ func ConvertRowValue(typMap *pgtype.Map, val []byte, typOID oid.Oid) (tree.Datum
 	case pgtype.NumericOID:
 		return tree.ParseDDecimal(string(val))
 	case pgtype.BitOID, pgtype.VarbitOID:
-		return tree.ParseDBitArray(string(val))
+		// val in this case is a []uint8.
+		// For example:
+		// b'1000001' -> {65}
+		// b'11110000011' -> {7, 131}
+		// b'111111111110000011' -> {3, 255, 131}
+		// We need to convert it into a bit array first.
+		paddedVal := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+		// Pad to the front to make it a byte slice of fixed length 8.
+		for p := 1; p < len(val)+1; p++ {
+			paddedVal[8-p] = val[len(val)-p]
+		}
+		theUint := binary.BigEndian.Uint64(paddedVal)
+		bitArrStr := strconv.FormatUint(theUint, 2)
+		return tree.ParseDBitArray(bitArrStr)
 	case oid.T_anyenum:
 		return tree.NewDString(string(val)), nil
 	}

--- a/mysqlconv/datum_converter_test.go
+++ b/mysqlconv/datum_converter_test.go
@@ -1,0 +1,78 @@
+package mysqlconv
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/types"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/molt/dbconn"
+	"github.com/cockroachdb/molt/testutils"
+	"github.com/lib/pq/oid"
+	"github.com/stretchr/testify/require"
+)
+
+func getOids(cmdArgs []datadriven.CmdArg) ([]oid.Oid, error) {
+	if len(cmdArgs) == 0 {
+		return nil, errors.AssertionFailedf("error: no oid provided")
+	}
+	var res []oid.Oid
+	for _, arg := range cmdArgs {
+		argInt, err := strconv.Atoi(arg.Vals[0])
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to convert arg %q to an oid", arg)
+		}
+		// Check if this is a valid oid.
+		_, ok := types.OidToType[oid.Oid(uint32(argInt))]
+		if !ok {
+			return nil, errors.AssertionFailedf("unknown oid: %d", argInt)
+		}
+		res = append(res, oid.Oid(uint32(argInt)))
+	}
+	return res, nil
+}
+
+func TestConvertRowValue(t *testing.T) {
+	ctx := context.Background()
+	const dbName = "mysql_test_conv_row_val"
+	dbConn, err := dbconn.TestOnlyCleanDatabase(ctx, "source", testutils.MySQLConnStr(), dbName)
+	require.NoError(t, err)
+	conn := dbConn.(*dbconn.MySQLConn)
+	defer func() { _ = conn.Close(ctx) }()
+	datadriven.Walk(t, "testdata/rowvalue", func(t *testing.T, path string) {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			var sb strings.Builder
+			switch d.Cmd {
+			case "convert":
+				oids, err := getOids(d.CmdArgs)
+				if err != nil {
+					sb.WriteString(err.Error())
+					return sb.String()
+				}
+				rows, err := conn.QueryContext(ctx, "SELECT "+d.Input)
+				require.NoError(t, err)
+
+				for rows.Next() {
+					datums, err := ScanRowDynamicTypes(rows, conn.TypeMap(), oids)
+					if err != nil {
+						sb.WriteString(fmt.Sprintf("scan row dynamic types error: %s\n", err.Error()))
+					}
+					for _, datum := range datums {
+						sb.WriteString(fmt.Sprintf("%T:%s;\n", datum, datum.String()))
+					}
+				}
+				if rows.Err() != nil {
+					sb.WriteString(fmt.Sprintf("query error: %s\n", rows.Err().Error()))
+				}
+				return sb.String()
+			default:
+				t.Fatalf("unknown command: %s", d.Cmd)
+			}
+			return sb.String()
+		})
+	})
+}

--- a/mysqlconv/testdata/rowvalue/bits.ddt
+++ b/mysqlconv/testdata/rowvalue/bits.ddt
@@ -1,0 +1,34 @@
+convert
+b'11110000011'
+----
+error: no oid provided
+
+convert oid=1560
+b'11110000011'
+----
+*tree.DBitArray:B'11110000011';
+
+convert oid=1560
+b'111111111110000011'
+----
+*tree.DBitArray:B'111111111110000011';
+
+convert oid=1560
+b'1'
+----
+*tree.DBitArray:B'1';
+
+convert oid=1560
+b'0'
+----
+*tree.DBitArray:B'0';
+
+convert oid=1565
+b'11110000011'
+----
+unknown oid: 1565
+
+convert oid=18
+b'11110000011'
+----
+scan row dynamic types error: value type OID 18 not yet translatable

--- a/mysqlconv/testdata/rowvalue/time.ddt
+++ b/mysqlconv/testdata/rowvalue/time.ddt
@@ -1,0 +1,34 @@
+convert oid=1083
+TIME('02:12:22')
+----
+*tree.DTime:'02:12:22';
+
+convert oid=1083
+TIME('02:12:22:0001')
+----
+*tree.DTime:'02:12:22';
+
+convert oid=1083
+TIME('-838:59:59')
+----
+*tree.DInterval:'-838:59:59';
+
+convert oid=1083
+TIME('-12:59:59')
+----
+*tree.DInterval:'-12:59:59';
+
+convert oid=1083
+TIME('00:11:12')
+----
+*tree.DTime:'00:11:12';
+
+convert oid=1083
+TIME('121312');
+----
+*tree.DTime:'12:13:12';
+
+convert oid=1083
+TIME('25:12:22')
+----
+*tree.DInterval:'25:12:22';

--- a/pgconv/testdata/rowvalue/bits.ddt
+++ b/pgconv/testdata/rowvalue/bits.ddt
@@ -1,0 +1,14 @@
+convert
+'1'::bit
+----
+*tree.DBitArray: B'1'
+
+convert
+'10001'::bit(4)
+----
+*tree.DBitArray: B'1000'
+
+convert
+'10001'::bit(5)
+----
+*tree.DBitArray: B'10001'

--- a/verify/tableverify/query.go
+++ b/verify/tableverify/query.go
@@ -131,7 +131,11 @@ ORDER BY ordinal_position`,
 			}
 			var cm Column
 			cm.Name = tree.Name(strings.ToLower(cn))
-			cm.OID = mysqlconv.DataTypeToOID(dt, ct)
+			typeOid, err := mysqlconv.DataTypeToOID(dt, ct)
+			if err != nil {
+				return ret, err
+			}
+			cm.OID = typeOid
 			cm.NotNull = isNullable == "NO"
 			cm.Collation = collation
 			ret = append(ret, cm)


### PR DESCRIPTION
Previous, the conversion of the bits type value from mysql to crdb is wrong, as it didn't correctly parse the value passed via the []uint8 val variable. We will get a 

```
22P02 Wraps: (2) could not parse string as bit array: "" is not a valid binary digit
```

error when trying to convert something like `b'11110000011'` into a `*tree.DBitArray`.

This PR is to fix it and add tests for it. 

Also added support for converting the time type.

Release note (bug fix): enable conversion of bit type entry from mysql to crdb. Add support for time type conversion too.