### PR TITLE
fetch: disallow truncate for import/copy only mode

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -325,10 +325,12 @@ func fetchTable(
 	}
 
 	// Truncate table on the target side, if applicable.
-	if cfg.Truncate {
+	if cfg.Truncate && !IsImportCopyOnlyMode(cfg) {
 		if err := truncateTable(ctx, logger, table, conns); err != nil {
 			return err
 		}
+	} else if cfg.Truncate && IsImportCopyOnlyMode(cfg) {
+		logger.Warn().Msg("truncate is skipped because you are using a continuation mode and it could result in missing data")
 	}
 
 	logger.Info().Msgf("data extraction phase starting")


### PR DESCRIPTION
Added logging for when we try to run truncate on import/copy only mode. Only allow truncate for full runs that don't try to continue in order to minimize risk of missing data.

Data could be missing if truncate happens because truncate removes all the data from a table. If a continuation is run on a file other than the first one, at least one section of the data will be removed. Truncate is now only allowed in the full run mode.

Release Note: None

```
(⎈|rancher-desktop:N/A)ryanluu@crlMBP-XFFK6Q9QL6MTk1 molt % go run . fetch \
  --source 'postgres://postgres:postgres@localhost:5432/molt?sslmode=disable' \
  --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' \
  --table-filter 'employees' \
  --local-path-listen-addr '0.0.0.0:9005' --bucket-path s3://molt-test --fetch-id 9e46b3bc-710e-48a6-905b-2bc496ee891a --table-ha
ndling "truncate-if-exists"
{"level":"info","time":"2024-02-27T12:15:59-05:00","message":"default compression to GZIP"}
{"level":"info","time":"2024-02-27T12:16:00-05:00","message":"checking database details"}
{"level":"info","source_table":"public.employees","target_table":"public.employees","time":"2024-02-27T12:16:00-05:00","message":"found matching table"}
{"level":"info","time":"2024-02-27T12:16:00-05:00","message":"verifying common tables"}
{"level":"info","time":"2024-02-27T12:16:00-05:00","message":"establishing snapshot"}
{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/3F41D08","time":"2024-02-27T12:16:00-05:00","message":"starting fetch"}
{"level":"warn","time":"2024-02-27T12:16:00-05:00","message":"truncate is skipped because you are using a continuation mode and it could result in missing data"}
```