### PR TITLE
MOLT: Bump to go 1.22

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: # Allow manual runs
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 
 jobs:
   run-e2e-tests:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 
 jobs:
   test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
   
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 
 jobs:
   release-cli:

--- a/go.mod
+++ b/go.mod
@@ -17,13 +17,13 @@ require (
 	github.com/jackc/pgx/v5 v5.5.1
 	github.com/jstemmer/go-junit-report v1.0.0
 	github.com/lib/pq v1.10.6
-	github.com/shopspring/decimal v1.3.1
 	github.com/pashagolub/pgxmock/v3 v3.3.0
 	github.com/pingcap/tidb v1.1.0-beta.0.20211124132551-4a1b2e9fe5b5
 	github.com/pingcap/tidb/parser v0.0.0-20211124132551-4a1b2e9fe5b5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/rs/zerolog v1.29.1
+	github.com/shopspring/decimal v1.3.1
 	github.com/sijms/go-ora/v2 v2.7.13
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
This commit bumps the molt repo to use go 1.22 for testing.

Release note: None