### PR TITLE
fetch: added in logic to enforce one active set of continuation tokens at a time     

### DIFF
--- a/cmd/fetch/fetch.go
+++ b/cmd/fetch/fetch.go
@@ -317,6 +317,15 @@ func Command() *cobra.Command {
 		"",
 		"If set, restarts the fetch process for at the given file name instead of recorded file in the exceptions table",
 	)
+
+	const nonInteractiveStr = "non-interactive"
+	cmd.PersistentFlags().BoolVar(
+		&cfg.NonInteractive,
+		nonInteractiveStr,
+		false,
+		`If set, automatically skips all user prompting and initiates actions such as clearing exception log data (preferable if running in CI)
+or as an automated job. If not set, prompts user for confirmation before performing actions.`,
+	)
 	moltlogger.RegisterLoggerFlags(cmd)
 	cmdutil.RegisterDBConnFlags(cmd)
 	cmdutil.RegisterNameFilterFlags(cmd)
@@ -334,6 +343,10 @@ func Command() *cobra.Command {
 	)
 
 	if err := cmd.PersistentFlags().MarkHidden(testOnlyFlagStr); err != nil {
+		panic(err)
+	}
+
+	if err := cmd.PersistentFlags().MarkHidden(nonInteractiveStr); err != nil {
 		panic(err)
 	}
 

--- a/fetch/copy.go
+++ b/fetch/copy.go
@@ -27,6 +27,8 @@ func Copy(
 	table dbtable.VerifiedTable,
 	resources []datablobstorage.Resource,
 	isLocal bool,
+	isClearContinuationTokenMode bool,
+	exceptionLog *status.ExceptionLog,
 ) (CopyResult, error) {
 	dataLogger := moltlogger.GetDataLogger(logger)
 	ret := CopyResult{
@@ -59,7 +61,7 @@ func Copy(
 				dataquery.CopyFrom(table, isLocal /*skips header if local */),
 			); err != nil {
 				fileName := path.Base(key)
-				return status.MaybeReportException(ctx, logger, conn, table.Name, err, fileName, status.StageDataLoad)
+				return status.MaybeReportException(ctx, logger, conn, table.Name, err, fileName, status.StageDataLoad, isClearContinuationTokenMode, exceptionLog)
 			} else {
 				rowsSoFar += int(copyRet.RowsAffected())
 				dataLogger.Info().

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -195,6 +195,7 @@ func TestDataDriven(t *testing.T) {
 								ContinuationToken:    continuationToken,
 								ContinuationFileName: overrideFile,
 								FlushRows:            flushRows,
+								NonInteractive:       true,
 							},
 							logger,
 							conns,
@@ -261,7 +262,7 @@ func TestInitStatusEntry(t *testing.T) {
 		require.NoError(t, err)
 		pgConn := conn.(*dbconn.PGConn).Conn
 
-		actual, err := initStatusEntry(ctx, pgConn, "PostgreSQL")
+		actual, err := initStatusEntry(ctx, Config{}, pgConn, "PostgreSQL")
 		require.NoError(t, err)
 		require.NotEqual(t, uuid.Nil, actual.ID)
 	})
@@ -273,7 +274,7 @@ func TestInitStatusEntry(t *testing.T) {
 		// Setup the tables that we need to write for status.
 		require.NoError(t, status.CreateStatusAndExceptionTables(ctx, pgConn))
 
-		actual, err := initStatusEntry(ctx, pgConn, "PostgreSQL")
+		actual, err := initStatusEntry(ctx, Config{}, pgConn, "PostgreSQL")
 		require.NoError(t, err)
 		require.NotEqual(t, uuid.Nil, actual.ID)
 	})

--- a/fetch/import_table.go
+++ b/fetch/import_table.go
@@ -138,6 +138,8 @@ func importTable(
 	resources []datablobstorage.Resource,
 	testingKnobs testutils.FetchTestingKnobs,
 	isLocal bool,
+	isClearContinuationTokenMode bool,
+	exceptionLog *status.ExceptionLog,
 ) (importResult, error) {
 	ret := importResult{
 		StartTime: time.Now(),
@@ -183,7 +185,7 @@ func importTable(
 		file, err := importWithBisect(ctx, kvOptions, table, logger, conn, locBatch)
 		if err != nil {
 			fileName := status.ExtractFileNameFromErr(file)
-			pgErr := status.MaybeReportException(ctx, logger, baseConn.(*dbconn.PGConn).Conn, table.Name, err, fileName, status.StageDataLoad)
+			pgErr := status.MaybeReportException(ctx, logger, baseConn.(*dbconn.PGConn).Conn, table.Name, err, fileName, status.StageDataLoad, isClearContinuationTokenMode, exceptionLog)
 			return ret, errors.Wrap(pgErr, "error importing data")
 		}
 

--- a/fetch/testdata/pg/continuation-edge-cases.ddt
+++ b/fetch/testdata/pg/continuation-edge-cases.ddt
@@ -165,16 +165,22 @@ TRUNCATE tbl2
 ----
 [target] TRUNCATE
 
+## Test that an invalid file name leads to an error that notes this.
+fetch live notruncate expect-error store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007 continuation-token=ab4762e5-6f70-43f8-8e15-58b4de10a007 override-file=wrong_00000003.csv
+----
+continuation file name wrong_00000003.csv doesn't match the format part_[\d+]{8}(\.csv|\.tar\.gz)
+
+# Insert an entry so that tbl1 entry is properly filled. Prev fetch wiped out tokens.
+exec target
+INSERT INTO _molt_fetch_exception (fetch_id, schema_name, table_name, file_name, sql_state, message, command, stage, time) VALUES ('d44762e5-6f70-43f8-8e15-58b4de10a007', 'public', 'tbl1', 'part_00000001.csv', '', '', '', '', now())
+----
+[target] INSERT 0 1
+
 # Make it so that the exception id is deterministic for future steps.
 exec target
 UPDATE _molt_fetch_exception SET id = 'ab4762e5-6f70-43f8-8e15-58b4de10a007' WHERE table_name LIKE 'tbl1'
 ----
 [target] UPDATE 1
-
-## Test that an invalid file name leads to an error that notes this.
-fetch live notruncate expect-error store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007 continuation-token=ab4762e5-6f70-43f8-8e15-58b4de10a007 override-file=wrong_00000003.csv
-----
-continuation file name wrong_00000003.csv doesn't match the format part_[\d+]{8}(\.csv|\.tar\.gz)
 
 ## Test that we can get the data from the overrided file and after.
 ## Test that even if irrelevant files with wrong data, it still works and writes the correct data
@@ -203,17 +209,17 @@ id	t
 77	ルカス
 tag: SELECT 3
 
+# Insert an entry so that tbl1 entry is properly filled. Prev fetch wiped out tokens.
+exec target
+INSERT INTO _molt_fetch_exception (fetch_id, schema_name, table_name, file_name, sql_state, message, command, stage, time) VALUES ('d44762e5-6f70-43f8-8e15-58b4de10a007', 'public', 'tbl1', 'part_00000001.csv', '', '', '', '', now())
+----
+[target] INSERT 0 1
+
 ## Test that when we run fetch continue on an entry with no associated file_name we error out.
 exec target
 UPDATE _molt_fetch_exception SET file_name='' WHERE table_name LIKE 'tbl%'
 ----
-[target] UPDATE 2
-
-# Make it so there is only one exception log, which can lead to better behavior for tests.
-exec target
-DELETE FROM _molt_fetch_exception WHERE table_name LIKE 'tbl2'
-----
-[target] DELETE 1
+[target] UPDATE 1
 
 # Run fetch and verify it fails with file name not found.
 fetch live notruncate expect-error store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007 cleanup-dir
@@ -224,7 +230,7 @@ table public.tbl1 not imported because no file name is present in the exception 
 exec target
 DELETE FROM _molt_fetch_exception WHERE table_name LIKE 'tbl%'
 ----
-[target] DELETE 1
+[target] DELETE 0
 
 query target
 SELECT fetch_id, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC

--- a/fetch/testdata/pg/continuation.ddt
+++ b/fetch/testdata/pg/continuation.ddt
@@ -90,13 +90,54 @@ UPDATE _molt_fetch_exception SET fetch_id = 'd44762e5-6f70-43f8-8e15-58b4de10a00
 
 # Ensure that the fetch_id stays consistent between test recordings.
 query target
-SELECT fetch_id, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
 ----
 [target]:
-fetch_id	table_name	message	sql_state	file_name	stage
-[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	tbl2	duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists.	23505	part_00000001.csv	data_load
-[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	tbl1	duplicate key value violates unique constraint "tbl1_pkey"; Key (id)=(11) already exists.	23505	part_00000001.csv	data_load
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl2	duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists.	23505	part_00000001.csv	data_load
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl1	duplicate key value violates unique constraint "tbl1_pkey"; Key (id)=(11) already exists.	23505	part_00000001.csv	data_load
 tag: SELECT 2
+
+# Baseline number of fetch entries.
+query target
+SELECT COUNT(*) FROM _molt_fetch_status;
+----
+[target]:
+count
+2
+tag: SELECT 1
+
+# Update the entry so we can continue from a known token we control.
+exec target
+UPDATE _molt_fetch_exception SET id = '011762e5-6f70-43f8-8e15-58b4de10a007' WHERE table_name LIKE 'tbl2'
+----
+[target] UPDATE 1
+
+## Test that when running continuation mode with specific table, when it errors we have
+## the same exception logs.
+
+# Setup this by updating the message field so that it is temporary. Then we need to verify that
+# the message gets updated back to the correct message down below.
+exec target 
+UPDATE _molt_fetch_exception SET message='temporary' WHERE table_name LIKE 'tbl2';
+----
+[target] UPDATE 1
+
+# As we expect the exception log tied to tbl2 shows the temporary message.
+query target
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
+----
+[target]:
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl2	temporary	23505	part_00000001.csv	data_load
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl1	duplicate key value violates unique constraint "tbl1_pkey"; Key (id)=(11) already exists.	23505	part_00000001.csv	data_load
+tag: SELECT 2
+
+# Run this continuation test first because it doesn't clear the exceptions log table.
+# Run fetch on only one table.
+fetch live expect-error  notruncate store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007 continuation-token=011762e5-6f70-43f8-8e15-58b4de10a007
+----
+ERROR: duplicate key value violates unique constraint "tbl2_pkey" (SQLSTATE 23505)
 
 # Clean up the target table and verify that it's cleaned.
 exec target
@@ -126,6 +167,113 @@ tag: SELECT 7
 id	t
 tag: SELECT 0
 
+# Ensure that there are still two exception logs when it fails.
+# Sure enough, the exception log gets updated with the latest message.
+query target
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
+----
+[target]:
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl2	duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists.	23505	part_00000001.csv	data_load
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl1	duplicate key value violates unique constraint "tbl1_pkey"; Key (id)=(11) already exists.	23505	part_00000001.csv	data_load
+tag: SELECT 2
+
+## Test that when running continuation mode with specific table, when it succeeds, we remove that token.
+# Run this continuation test first because it doesn't clear the exceptions log table.
+# Run fetch on only one table.
+fetch live notruncate store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007 continuation-token=011762e5-6f70-43f8-8e15-58b4de10a007
+----
+
+# Ensures there is only one log left since the one for tbl2 got removed.
+query target
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
+----
+[target]:
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl1	duplicate key value violates unique constraint "tbl1_pkey"; Key (id)=(11) already exists.	23505	part_00000001.csv	data_load
+tag: SELECT 1
+
+# Verify that there are no new fetch IDs.
+query target
+SELECT COUNT(*) FROM _molt_fetch_status;
+----
+[target]:
+count
+2
+tag: SELECT 1
+
+# Verify that the continuation worked and that data for table 2 is loaded properly.
+# Table 1 should not have any data loaded.
+query all
+SELECT * FROM tbl1
+----
+[source]:
+id	t
+11	aaa
+22	bb b
+33	ééé
+44	🫡🫡🫡
+55	娜娜
+66	Лукас
+77	ルカス
+tag: SELECT 7
+[target]:
+id	t
+tag: SELECT 0
+
+query all
+SELECT * FROM tbl2
+----
+[source]:
+id	t
+0	aaa
+55	bb b
+66	ééé
+77	🫡🫡🫡
+88	娜娜
+1010	Лукас
+1212	ルカス
+tag: SELECT 7
+[target]:
+id	t
+0	aaa
+55	bb b
+66	ééé
+77	🫡🫡🫡
+88	娜娜
+1010	Лукас
+1212	ルカス
+tag: SELECT 7
+
+# Cleanup both tables on the target.
+exec target
+TRUNCATE tbl1
+----
+[target] TRUNCATE
+
+exec target
+TRUNCATE tbl2
+----
+[target] TRUNCATE
+
+# Insert an entry so that tbl2 is properly filled.
+exec target
+INSERT INTO _molt_fetch_exception (fetch_id, schema_name, table_name, file_name, sql_state, message, command, stage, time) VALUES ('d44762e5-6f70-43f8-8e15-58b4de10a007', 'public', 'tbl2', 'part_00000001.csv', '', '', '', '', now())
+----
+[target] INSERT 0 1
+
+# Ensure that the fetch_id stays consistent between test recordings.
+query target
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
+----
+[target]:
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl2			part_00000001.csv	
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl1	duplicate key value violates unique constraint "tbl1_pkey"; Key (id)=(11) already exists.	23505	part_00000001.csv	data_load
+tag: SELECT 2
+
+## Test import-copy only mode with only fetch ID specified wipes all existing tokens.
+# This mode of fetch with fetch ID specified will automatically truncate the _molt_fetch_exception table.
 # Run fetch with continue and verify that it loads the data properly.
 fetch live notruncate store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007
 ----
@@ -179,66 +327,58 @@ id	t
 1212	ルカス
 tag: SELECT 7
 
-# Cleanup both tables on the target.
-exec target
-TRUNCATE tbl1
+# Ensure that fetch exception table is now empty.
+query target
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
 ----
-[target] TRUNCATE
-
-exec target
-TRUNCATE tbl2
-----
-[target] TRUNCATE
-
-# Update the entry so we can continue from a known token we control.
-exec target
-UPDATE _molt_fetch_exception SET id = '011762e5-6f70-43f8-8e15-58b4de10a007' WHERE table_name LIKE 'tbl2'
-----
-[target] UPDATE 1
-
-# Run fetch again on only one table.
-fetch live notruncate cleanup-dir store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007 continuation-token=011762e5-6f70-43f8-8e15-58b4de10a007
-----
-
-# Verify that the continuation worked and that data for table 2 is loaded properly.
-# Table 1 should not have any data loaded.
-query all
-SELECT * FROM tbl1
-----
-[source]:
-id	t
-11	aaa
-22	bb b
-33	ééé
-44	🫡🫡🫡
-55	娜娜
-66	Лукас
-77	ルカス
-tag: SELECT 7
 [target]:
-id	t
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
 tag: SELECT 0
 
-query all
-SELECT * FROM tbl2
+# Ensure that we have a new fetch ID in the table.
+query target
+SELECT COUNT(*) FROM _molt_fetch_status;
 ----
-[source]:
-id	t
-0	aaa
-55	bb b
-66	ééé
-77	🫡🫡🫡
-88	娜娜
-1010	Лукас
-1212	ルカス
-tag: SELECT 7
 [target]:
-id	t
-0	aaa
-55	bb b
-66	ééé
-77	🫡🫡🫡
-88	娜娜
-1010	Лукас
-1212	ルカス
-tag: SELECT 7
+count
+3
+tag: SELECT 1
+
+## Test that on error in continuation mode with only fetch-id
+## the token's fetch ID are now tied to a new one.
+# Insert an entry so that tbl2 is properly filled.
+exec target
+INSERT INTO _molt_fetch_exception (fetch_id, schema_name, table_name, file_name, sql_state, message, command, stage, time) VALUES ('d44762e5-6f70-43f8-8e15-58b4de10a007', 'public', 'tbl2', 'part_00000001.csv', '', 'duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists', '', '', now())
+----
+[target] INSERT 0 1
+
+# Ensure that the fetch_id stays consistent between test recordings.
+query target
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exception ORDER BY table_name DESC
+----
+[target]:
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl2	duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists		part_00000001.csv	
+tag: SELECT 1
+
+# Ensure that we see 1 item that has fetch_id of what we specified above.
+query target
+SELECT COUNT(*) FROM _molt_fetch_exception WHERE fetch_id='d44762e5-6f70-43f8-8e15-58b4de10a007';
+----
+[target]:
+count
+1
+tag: SELECT 1
+
+fetch live expect-error notruncate cleanup-dir store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007
+----
+ERROR: duplicate key value violates unique constraint "tbl2_pkey" (SQLSTATE 23505)
+
+# Note that we no longer have any exception log tokens that match the fetch_id.
+query target
+SELECT COUNT(*) FROM _molt_fetch_exception WHERE fetch_id='d44762e5-6f70-43f8-8e15-58b4de10a007';
+----
+[target]:
+count
+0
+tag: SELECT 1


### PR DESCRIPTION
The behavior introduced makes it so that customers only have one set of continuation tokens that are tied to a single fetch ID. This solves the problem of not using stale tokens that may correspond to older versions of the data set. At a high level, this is the behavior:

- If not import-copy only mode: we wipe the existing tokens before we run, generate a new fetch ID, tie the exceptions log entries to new fetch ID
- If import-copy only mode but ONLY fetch ID specified: we wipe the existing tokens before we run, generate a new fetch ID, tie the exceptions log entries to new fetch ID
- If import-copy only mode and BOTH fetch ID and cont token specified: we keep the existing tokens; if it succeeds, we delete the token from the exceptions log table; if it fails, we update the entry with the fetch ID with the latest details
 
Resolves: CC-27326
Release Note: None