### PR TITLE
[CC-27357] fetch: enable fetch dropped constraints

### DIFF
--- a/e2e/testdata/mysql/bool.ddt
+++ b/e2e/testdata/mysql/bool.ddt
@@ -37,6 +37,7 @@ fetch --source 'mysql://user:password@0.0.0.0:3306/defaultdb' --target 'postgres
 {"level":"info","message":"getting column types for table: public.bool_table"}
 {"level":"info","message":"finished getting column types for table: public.bool_table"}
 {"level":"info","message":"creating new table with \"CREATE TABLE bool_table (id INT8 NOT NULL PRIMARY KEY, bool_col INT2)\""}
+{"level":"warn","message":"newly created schema doesn't contain the following constraints:\ntable: public.bool_table,\"UNIQUE KEY `id` (`id`)\""}
 {"level":"info","message":"after recreating table, dbTables: {[[public.bool_table public.bool_table]] [] []}"}
 {"level":"info","message":"verifying common tables"}
 {"level":"info","message":"establishing snapshot"}

--- a/e2e/testdata/mysql/schema_creation_dropped_constraints.ddt
+++ b/e2e/testdata/mysql/schema_creation_dropped_constraints.ddt
@@ -1,0 +1,115 @@
+exec silent
+mysql -u user -p'password'  -h '0.0.0.0' -P 3306 --database=defaultdb --execute="CREATE TABLE tenants (tenant_id integer PRIMARY KEY);"
+----
+
+exec silent
+mysql -u user -p'password'  -h '0.0.0.0' -P 3306 --database=defaultdb --execute="CREATE TABLE users (tenant_id INTEGER REFERENCES tenants ON DELETE CASCADE, user_id INTEGER NOT NULL UNIQUE, age INTEGER CHECK (age > 18), PRIMARY KEY (tenant_id, user_id));"
+----
+
+exec silent
+mysql -u user -p'password'  -h '0.0.0.0' -P 3306 --database=defaultdb --execute="CREATE TABLE posts (tenant_id INTEGER, post_id INTEGER NOT NULL, author_id INTEGER UNIQUE, number INTEGER CHECK (number > 10) UNIQUE, PRIMARY KEY (post_id), FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE RESTRICT, FOREIGN KEY (tenant_id, author_id) REFERENCES users(tenant_id, user_id) ON DELETE SET NULL);"
+----
+
+exec silent
+docker exec -t github-mysql-1 mysql -u root -e 'GRANT FILE, SELECT on *.* to user;'
+----
+
+fetch --source 'mysql://user:password@0.0.0.0:3306/defaultdb' --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --table-filter 'users' --local-path /tmp/basic --local-path-listen-addr '0.0.0.0:9115' --table-handling 'drop-on-target-and-recreate' --cleanup=true
+----
+{"level":"info","message":"default compression to GZIP"}
+{"level":"info","message":"checking database details"}
+{"level":"info","message":"creating schema for tables: [public.users]"}
+{"level":"info","message":"getting column types for table: public.users"}
+{"level":"info","message":"finished getting column types for table: public.users"}
+{"level":"info","message":"creating new table with \"CREATE TABLE users (tenant_id INT4 NOT NULL, user_id INT4 NOT NULL, age INT4, CONSTRAINT \\\"primary\\\" PRIMARY KEY (tenant_id, user_id))\""}
+{"level":"warn","message":"newly created schema doesn't contain the following constraints:\ntable: public.users,\"UNIQUE KEY `user_id` (`user_id`)\",\"CONSTRAINT `users_chk_1` CHECK ((`age` > 18))\""}
+{"level":"info","message":"after recreating table, dbTables: {[[public.users public.users]] [] []}"}
+{"level":"info","message":"verifying common tables"}
+{"level":"info","message":"establishing snapshot"}
+{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/19E3610","message":"starting fetch"}
+{"level":"info","message":"data extraction phase starting"}
+{"level":"info","type":"summary","num_rows":0,"export_duration_ms":1000,"export_duration":"000h 00m 01s","message":"data extraction from source complete"}
+{"level":"info","message":"starting data import on target"}
+{"level":"info","type":"summary","net_duration_ms":1000,"net_duration":"000h 00m 01s","import_duration_ms":1000,"import_duration":"000h 00m 01s","export_duration_ms":1000,"export_duration":"000h 00m 01s","num_rows":0,"cdc_cursor":"0/19E3610","message":"data import on target for table complete"}
+{"level":"info","message":"cleaning up resources created during fetch run"}
+{"level":"info","type":"summary","fetch_id":"0000000000","num_tables":1,"tables":["public.users"],"cdc_cursor":"0/19E3610","net_duration_ms":1000,"net_duration":"000h 00m 01s","message":"fetch complete"}
+{"level":"info","message":"http server intentionally shut down"}
+
+fetch --source 'mysql://user:password@0.0.0.0:3306/defaultdb' --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --table-filter 'posts' --local-path /tmp/basic --local-path-listen-addr '0.0.0.0:9115' --table-handling 'drop-on-target-and-recreate' --cleanup=true
+----
+{"level":"info","message":"default compression to GZIP"}
+{"level":"info","message":"checking database details"}
+{"level":"info","message":"creating schema for tables: [public.posts]"}
+{"level":"info","message":"getting column types for table: public.posts"}
+{"level":"info","message":"finished getting column types for table: public.posts"}
+{"level":"info","message":"creating new table with \"CREATE TABLE posts (tenant_id INT4, post_id INT4 NOT NULL PRIMARY KEY, author_id INT4, number INT4)\""}
+{"level":"warn","message":"newly created schema doesn't contain the following constraints:\ntable: public.posts,\"UNIQUE KEY `author_id` (`author_id`)\",\"UNIQUE KEY `number` (`number`)\",\"CONSTRAINT `posts_ibfk_1` FOREIGN KEY (`tenant_id`) REFERENCES `tenants` (`tenant_id`) ON DELETE RESTRICT\",\"CONSTRAINT `posts_ibfk_2` FOREIGN KEY (`tenant_id`, `author_id`) REFERENCES `users` (`tenant_id`, `user_id`) ON DELETE SET NULL\",\"CONSTRAINT `posts_chk_1` CHECK ((`number` > 10))\""}
+{"level":"info","message":"after recreating table, dbTables: {[[public.posts public.posts]] [] []}"}
+{"level":"info","message":"verifying common tables"}
+{"level":"info","message":"establishing snapshot"}
+{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/19E3610","message":"starting fetch"}
+{"level":"info","message":"data extraction phase starting"}
+{"level":"info","type":"summary","num_rows":0,"export_duration_ms":1000,"export_duration":"000h 00m 01s","message":"data extraction from source complete"}
+{"level":"info","message":"starting data import on target"}
+{"level":"info","type":"summary","net_duration_ms":1000,"net_duration":"000h 00m 01s","import_duration_ms":1000,"import_duration":"000h 00m 01s","export_duration_ms":1000,"export_duration":"000h 00m 01s","num_rows":0,"cdc_cursor":"0/19E3610","message":"data import on target for table complete"}
+{"level":"info","message":"cleaning up resources created during fetch run"}
+{"level":"info","type":"summary","fetch_id":"0000000000","num_tables":1,"tables":["public.posts"],"cdc_cursor":"0/19E3610","net_duration_ms":1000,"net_duration":"000h 00m 01s","message":"fetch complete"}
+{"level":"info","message":"http server intentionally shut down"}
+
+fetch --source 'mysql://user:password@0.0.0.0:3306/defaultdb' --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --table-filter 'tenants' --local-path /tmp/basic --local-path-listen-addr '0.0.0.0:9115' --table-handling 'drop-on-target-and-recreate' --cleanup=true
+----
+{"level":"info","message":"default compression to GZIP"}
+{"level":"info","message":"checking database details"}
+{"level":"info","message":"creating schema for tables: [public.tenants]"}
+{"level":"info","message":"getting column types for table: public.tenants"}
+{"level":"info","message":"finished getting column types for table: public.tenants"}
+{"level":"info","message":"creating new table with \"CREATE TABLE tenants (tenant_id INT4 NOT NULL PRIMARY KEY)\""}
+{"level":"info","message":"after recreating table, dbTables: {[[public.tenants public.tenants]] [] []}"}
+{"level":"info","message":"verifying common tables"}
+{"level":"info","message":"establishing snapshot"}
+{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/19E3610","message":"starting fetch"}
+{"level":"info","message":"data extraction phase starting"}
+{"level":"info","type":"summary","num_rows":0,"export_duration_ms":1000,"export_duration":"000h 00m 01s","message":"data extraction from source complete"}
+{"level":"info","message":"starting data import on target"}
+{"level":"info","type":"summary","net_duration_ms":1000,"net_duration":"000h 00m 01s","import_duration_ms":1000,"import_duration":"000h 00m 01s","export_duration_ms":1000,"export_duration":"000h 00m 01s","num_rows":0,"cdc_cursor":"0/19E3610","message":"data import on target for table complete"}
+{"level":"info","message":"cleaning up resources created during fetch run"}
+{"level":"info","type":"summary","fetch_id":"0000000000","num_tables":1,"tables":["public.tenants"],"cdc_cursor":"0/19E3610","net_duration_ms":1000,"net_duration":"000h 00m 01s","message":"fetch complete"}
+{"level":"info","message":"http server intentionally shut down"}
+
+exec
+psql 'postgres://root@localhost:26257/defaultdb?sslmode=disable' -c "SHOW CREATE TABLE posts"
+----
+table_name |                    create_statement                     
+------------+---------------------------------------------------------
+ posts      | CREATE TABLE public.posts (                            +
+            |         tenant_id INT4 NULL,                           +
+            |         post_id INT4 NOT NULL,                         +
+            |         author_id INT4 NULL,                           +
+            |         number INT4 NULL,                              +
+            |         CONSTRAINT posts_pkey PRIMARY KEY (post_id ASC)+
+            | )
+(1 row)
+
+exec
+psql 'postgres://root@localhost:26257/defaultdb?sslmode=disable' -c "SHOW CREATE TABLE users"
+----
+table_name |                           create_statement                            
+------------+-----------------------------------------------------------------------
+ users      | CREATE TABLE public.users (                                          +
+            |         tenant_id INT4 NOT NULL,                                     +
+            |         user_id INT4 NOT NULL,                                       +
+            |         age INT4 NULL,                                               +
+            |         CONSTRAINT "primary" PRIMARY KEY (tenant_id ASC, user_id ASC)+
+            | )
+(1 row)
+
+exec
+psql 'postgres://root@localhost:26257/defaultdb?sslmode=disable' -c "SHOW CREATE TABLE tenants"
+----
+table_name |                      create_statement                       
+------------+-------------------------------------------------------------
+ tenants    | CREATE TABLE public.tenants (                              +
+            |         tenant_id INT4 NOT NULL,                           +
+            |         CONSTRAINT tenants_pkey PRIMARY KEY (tenant_id ASC)+
+            | )
+(1 row)

--- a/e2e/testdata/mysql/uuid.ddt
+++ b/e2e/testdata/mysql/uuid.ddt
@@ -28,6 +28,7 @@ fetch --source 'mysql://user:password@0.0.0.0:3306/defaultdb' --target 'postgres
 {"level":"info","message":"getting column types for table: public.uuid_table"}
 {"level":"info","message":"finished getting column types for table: public.uuid_table"}
 {"level":"info","message":"creating new table with \"CREATE TABLE uuid_table (id INT8 NOT NULL PRIMARY KEY, unique_id VARCHAR)\""}
+{"level":"warn","message":"newly created schema doesn't contain the following constraints:\ntable: public.uuid_table,\"UNIQUE KEY `id` (`id`)\""}
 {"level":"info","message":"after recreating table, dbTables: {[[public.uuid_table public.uuid_table]] [] []}"}
 {"level":"info","message":"verifying common tables"}
 {"level":"info","message":"establishing snapshot"}

--- a/e2e/testdata/pg/schema_creation.ddt
+++ b/e2e/testdata/pg/schema_creation.ddt
@@ -127,6 +127,7 @@ fetch --source 'postgres://postgres@localhost:5432/defaultdb' --target 'postgres
 {"level":"info","message":"getting column types for table: public.employee1"}
 {"level":"info","message":"finished getting column types for table: public.employee1"}
 {"level":"info","message":"creating new table with \"CREATE TABLE employee1 (id INT4 NOT NULL PRIMARY KEY, name VARCHAR NOT NULL, age INT4, address VARCHAR NOT NULL, start_date DATE, end_date DATE)\""}
+{"level":"warn","message":"newly created schema doesn't contain the following constraints:\ntable: public.employee1,\"CHECK ((start_date <= end_date))\",\"UNIQUE (name)\",\"UNIQUE (start_date)\""}
 {"level":"info","message":"after recreating table, dbTables: {[[public.employee1 public.employee1]] [] []}"}
 {"level":"info","message":"verifying common tables"}
 {"level":"info","message":"establishing snapshot"}

--- a/e2e/testdata/pg/schema_creation_dropped_constraints.ddt
+++ b/e2e/testdata/pg/schema_creation_dropped_constraints.ddt
@@ -1,0 +1,111 @@
+exec silent
+psql 'postgres://postgres@localhost:5432/defaultdb' -c "CREATE TABLE tenants (tenant_id integer PRIMARY KEY);"
+----
+
+exec silent
+psql 'postgres://postgres@localhost:5432/defaultdb' -c "CREATE TABLE users (tenant_id INTEGER REFERENCES tenants ON DELETE CASCADE, user_id INTEGER NOT NULL UNIQUE, age INTEGER CHECK (age > 18), PRIMARY KEY (tenant_id, user_id));"
+----
+
+exec silent
+psql 'postgres://postgres@localhost:5432/defaultdb' -c "CREATE TABLE posts (tenant_id INTEGER REFERENCES tenants ON DELETE RESTRICT, post_id INTEGER NOT NULL, author_id INTEGER UNIQUE, number_pg INTEGER UNIQUE, PRIMARY KEY (tenant_id, post_id), FOREIGN KEY (tenant_id, author_id) REFERENCES users ON DELETE SET NULL);"
+----
+
+fetch --source 'postgres://postgres@localhost:5432/defaultdb' --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --table-filter 'users' --local-path /tmp/basic --local-path-listen-addr '0.0.0.0:9115' --table-handling 'drop-on-target-and-recreate'  --cleanup=true
+----
+{"level":"info","message":"default compression to GZIP"}
+{"level":"info","message":"checking database details"}
+{"level":"info","message":"creating schema for tables: [public.users]"}
+{"level":"info","message":"getting column types for table: public.users"}
+{"level":"info","message":"finished getting column types for table: public.users"}
+{"level":"info","message":"creating new table with \"CREATE TABLE users (tenant_id INT4 NOT NULL, user_id INT4 NOT NULL, age INT4, CONSTRAINT \\\"primary\\\" PRIMARY KEY (tenant_id, user_id))\""}
+{"level":"warn","message":"newly created schema doesn't contain the following constraints:\ntable: public.users,\"CHECK ((age > 18))\",\"FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE\",\"UNIQUE (user_id)\""}
+{"level":"info","message":"after recreating table, dbTables: {[[public.users public.users]] [] []}"}
+{"level":"info","message":"verifying common tables"}
+{"level":"info","message":"establishing snapshot"}
+{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/19E3610","message":"starting fetch"}
+{"level":"info","message":"data extraction phase starting"}
+{"level":"info","type":"summary","num_rows":0,"export_duration_ms":1000,"export_duration":"000h 00m 01s","message":"data extraction from source complete"}
+{"level":"info","message":"starting data import on target"}
+{"level":"info","type":"summary","net_duration_ms":1000,"net_duration":"000h 00m 01s","import_duration_ms":1000,"import_duration":"000h 00m 01s","export_duration_ms":1000,"export_duration":"000h 00m 01s","num_rows":0,"cdc_cursor":"0/19E3610","message":"data import on target for table complete"}
+{"level":"info","message":"cleaning up resources created during fetch run"}
+{"level":"info","type":"summary","fetch_id":"0000000000","num_tables":1,"tables":["public.users"],"cdc_cursor":"0/19E3610","net_duration_ms":1000,"net_duration":"000h 00m 01s","message":"fetch complete"}
+{"level":"info","message":"http server intentionally shut down"}
+
+fetch --source 'postgres://postgres@localhost:5432/defaultdb' --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --table-filter 'tenants' --local-path /tmp/basic --local-path-listen-addr '0.0.0.0:9115' --table-handling 'drop-on-target-and-recreate'  --cleanup=true
+----
+{"level":"info","message":"default compression to GZIP"}
+{"level":"info","message":"checking database details"}
+{"level":"info","message":"creating schema for tables: [public.tenants]"}
+{"level":"info","message":"getting column types for table: public.tenants"}
+{"level":"info","message":"finished getting column types for table: public.tenants"}
+{"level":"info","message":"creating new table with \"CREATE TABLE tenants (tenant_id INT4 NOT NULL PRIMARY KEY)\""}
+{"level":"info","message":"after recreating table, dbTables: {[[public.tenants public.tenants]] [] []}"}
+{"level":"info","message":"verifying common tables"}
+{"level":"info","message":"establishing snapshot"}
+{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/19E3610","message":"starting fetch"}
+{"level":"info","message":"data extraction phase starting"}
+{"level":"info","type":"summary","num_rows":0,"export_duration_ms":1000,"export_duration":"000h 00m 01s","message":"data extraction from source complete"}
+{"level":"info","message":"starting data import on target"}
+{"level":"info","type":"summary","net_duration_ms":1000,"net_duration":"000h 00m 01s","import_duration_ms":1000,"import_duration":"000h 00m 01s","export_duration_ms":1000,"export_duration":"000h 00m 01s","num_rows":0,"cdc_cursor":"0/19E3610","message":"data import on target for table complete"}
+{"level":"info","message":"cleaning up resources created during fetch run"}
+{"level":"info","type":"summary","fetch_id":"0000000000","num_tables":1,"tables":["public.tenants"],"cdc_cursor":"0/19E3610","net_duration_ms":1000,"net_duration":"000h 00m 01s","message":"fetch complete"}
+{"level":"info","message":"http server intentionally shut down"}
+
+fetch --source 'postgres://postgres@localhost:5432/defaultdb' --target 'postgres://root@localhost:26257/defaultdb?sslmode=disable' --table-filter 'posts' --local-path /tmp/basic --local-path-listen-addr '0.0.0.0:9115' --table-handling 'drop-on-target-and-recreate'  --cleanup=true
+----
+{"level":"info","message":"default compression to GZIP"}
+{"level":"info","message":"checking database details"}
+{"level":"info","message":"creating schema for tables: [public.posts]"}
+{"level":"info","message":"getting column types for table: public.posts"}
+{"level":"info","message":"finished getting column types for table: public.posts"}
+{"level":"info","message":"creating new table with \"CREATE TABLE posts (tenant_id INT4 NOT NULL, post_id INT4 NOT NULL, author_id INT4, number_pg INT4, CONSTRAINT \\\"primary\\\" PRIMARY KEY (tenant_id, post_id))\""}
+{"level":"warn","message":"newly created schema doesn't contain the following constraints:\ntable: public.posts,\"UNIQUE (author_id)\",\"UNIQUE (number_pg)\",\"FOREIGN KEY (tenant_id, author_id) REFERENCES users(tenant_id, user_id) ON DELETE SET NULL\",\"FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE RESTRICT\""}
+{"level":"info","message":"after recreating table, dbTables: {[[public.posts public.posts]] [] []}"}
+{"level":"info","message":"verifying common tables"}
+{"level":"info","message":"establishing snapshot"}
+{"level":"info","type":"summary","num_tables":1,"cdc_cursor":"0/19E3610","message":"starting fetch"}
+{"level":"info","message":"data extraction phase starting"}
+{"level":"info","type":"summary","num_rows":0,"export_duration_ms":1000,"export_duration":"000h 00m 01s","message":"data extraction from source complete"}
+{"level":"info","message":"starting data import on target"}
+{"level":"info","type":"summary","net_duration_ms":1000,"net_duration":"000h 00m 01s","import_duration_ms":1000,"import_duration":"000h 00m 01s","export_duration_ms":1000,"export_duration":"000h 00m 01s","num_rows":0,"cdc_cursor":"0/19E3610","message":"data import on target for table complete"}
+{"level":"info","message":"cleaning up resources created during fetch run"}
+{"level":"info","type":"summary","fetch_id":"0000000000","num_tables":1,"tables":["public.posts"],"cdc_cursor":"0/19E3610","net_duration_ms":1000,"net_duration":"000h 00m 01s","message":"fetch complete"}
+{"level":"info","message":"http server intentionally shut down"}
+
+exec
+psql 'postgres://root@localhost:26257/defaultdb?sslmode=disable' -c "SHOW CREATE TABLE posts"
+----
+table_name |                           create_statement                            
+------------+-----------------------------------------------------------------------
+ posts      | CREATE TABLE public.posts (                                          +
+            |         tenant_id INT4 NOT NULL,                                     +
+            |         post_id INT4 NOT NULL,                                       +
+            |         author_id INT4 NULL,                                         +
+            |         number_pg INT4 NULL,                                         +
+            |         CONSTRAINT "primary" PRIMARY KEY (tenant_id ASC, post_id ASC)+
+            | )
+(1 row)
+
+exec
+psql 'postgres://root@localhost:26257/defaultdb?sslmode=disable' -c "SHOW CREATE TABLE users"
+----
+table_name |                           create_statement                            
+------------+-----------------------------------------------------------------------
+ users      | CREATE TABLE public.users (                                          +
+            |         tenant_id INT4 NOT NULL,                                     +
+            |         user_id INT4 NOT NULL,                                       +
+            |         age INT4 NULL,                                               +
+            |         CONSTRAINT "primary" PRIMARY KEY (tenant_id ASC, user_id ASC)+
+            | )
+(1 row)
+
+exec
+psql 'postgres://root@localhost:26257/defaultdb?sslmode=disable' -c "SHOW CREATE TABLE tenants"
+----
+table_name |                      create_statement                       
+------------+-------------------------------------------------------------
+ tenants    | CREATE TABLE public.tenants (                              +
+            |         tenant_id INT4 NOT NULL,                           +
+            |         CONSTRAINT tenants_pkey PRIMARY KEY (tenant_id ASC)+
+            | )
+(1 row)

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -161,6 +161,16 @@ func Fetch(
 					return errors.Wrapf(err, "failed to create new schema %q on the target connection with %q", t, createTableStmt)
 				}
 				logger.Debug().Msgf("finished creating new table with %q", createTableStmt)
+
+				// TODO(janexing): maybe persist it in table?
+				droppedConstraints, err := GetConstraints(ctx, logger, conns[0], t)
+				if err != nil {
+					return err
+				}
+				if len(droppedConstraints) != 0 {
+					consWithTable := constraintsWithTable{table: t, cons: droppedConstraints}
+					logger.Warn().Msgf("newly created schema doesn't contain the following constraints:\n%s", consWithTable.String())
+				}
 			}
 			// Redo the verify.
 			dbTables, err = dbverify.Verify(ctx, conns)

--- a/go.mod
+++ b/go.mod
@@ -17,13 +17,13 @@ require (
 	github.com/jackc/pgx/v5 v5.5.1
 	github.com/jstemmer/go-junit-report v1.0.0
 	github.com/lib/pq v1.10.6
-	github.com/shopspring/decimal v1.3.1
 	github.com/pashagolub/pgxmock/v3 v3.3.0
 	github.com/pingcap/tidb v1.1.0-beta.0.20211124132551-4a1b2e9fe5b5
 	github.com/pingcap/tidb/parser v0.0.0-20211124132551-4a1b2e9fe5b5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/rs/zerolog v1.29.1
+	github.com/shopspring/decimal v1.3.1
 	github.com/sijms/go-ora/v2 v2.7.13
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Now we can collect the non-primary constraints from the given table. It is logged as a warn. 

Example:

```
{"level":"warn","message":"newly created schema doesn't contain the following constraints:\ntable: public.posts,\"UNIQUE (author_id)\",\"UNIQUE (number_pg)\",\"FOREIGN KEY (tenant_id, author_id) REFERENCES users(tenant_id, user_id) ON DELETE SET NULL\",\"FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE RESTRICT\""}
```

- [x]  **E2E passed**: https://github.com/cockroachdb/molt/actions/runs/8102733772

Jira ticket: https://cockroachlabs.atlassian.net/browse/CC-27357
Release note: none