### PR TITLE
cmd/fetch/tokens: add in a new feature to list out all active continuation tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work
 task.log
 *.log
 .vscode/
+fetch/continuation-test/

--- a/cmd/fetch/tokens/list.go
+++ b/cmd/fetch/tokens/list.go
@@ -1,0 +1,70 @@
+package tokens
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cockroachdb/molt/dbconn"
+	"github.com/cockroachdb/molt/fetch"
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	var connString string
+	var numResults int
+	var testOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "tokens list",
+		Short: "List details about each continuation token.",
+		Long:  `List details about each continuation token.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			conn, err := dbconn.Connect(ctx, "target", connString)
+			if err != nil {
+				return err
+			}
+
+			targetPgConn, valid := conn.(*dbconn.PGConn)
+			if !valid {
+				return errors.New("failed to assert conn as a pgconn")
+			}
+			targetPgxConn := targetPgConn.Conn
+
+			tableStr, err := fetch.ListContinuationTokens(ctx, testOnly, targetPgxConn, numResults)
+			if err != nil {
+				return err
+			}
+
+			_, err = cmd.OutOrStdout().Write([]byte(tableStr))
+			return err
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(
+		&connString,
+		"conn-string",
+		"",
+		"Connection string of the database which has the _molt_fetch metadata.",
+	)
+	cmd.PersistentFlags().IntVarP(
+		&numResults,
+		"num-results",
+		"n",
+		0,
+		"Number of results to return",
+	)
+	cmd.PersistentFlags().BoolVarP(
+		&testOnly,
+		"test-only",
+		"t",
+		false,
+		"If set, runs in test mode with deterministic data.",
+	)
+
+	if err := cmd.MarkPersistentFlagRequired("conn-string"); err != nil {
+		panic(err)
+	}
+
+	return cmd
+}

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -222,6 +222,35 @@ func TestDataDriven(t *testing.T) {
 						}
 						require.NoError(t, err)
 						return ""
+					case "list-tokens":
+						// We don't want to clean the database in this case.
+						targetConn := conns[1]
+						targetPgConn, valid := targetConn.(*dbconn.PGConn)
+						require.Equal(t, true, valid)
+
+						numResults := 5
+
+						for _, cmd := range d.CmdArgs {
+							switch cmd.Key {
+							case "num-results":
+								res, err := strconv.Atoi(cmd.Vals[0])
+								require.NoError(t, err)
+								numResults = res
+							default:
+								t.Errorf("unknown key %s", cmd.Key)
+							}
+						}
+
+						val, err := ListContinuationTokens(ctx, true /*testOnly*/, targetPgConn.Conn, numResults)
+
+						if !expectError {
+							require.NoError(t, err)
+							return val
+						} else {
+							require.Error(t, err)
+							return err.Error()
+						}
+
 					default:
 						t.Errorf("unknown command: %s", d.Cmd)
 					}

--- a/fetch/testdata/pg/list-tokens.ddt
+++ b/fetch/testdata/pg/list-tokens.ddt
@@ -1,0 +1,72 @@
+# Testing for duplicate key errors.
+exec all
+CREATE TABLE tbl1(id INT PRIMARY KEY, t TEXT)
+----
+[source] CREATE TABLE
+[target] CREATE TABLE
+
+exec all
+CREATE TABLE tbl2(id INT PRIMARY KEY, t TEXT)
+----
+[source] CREATE TABLE
+[target] CREATE TABLE
+
+# Seeds the data so we force a collision.
+exec all
+INSERT INTO tbl1 VALUES (11, 'aaa'), (22, 'bb b'), (33, 'ééé'), (44, '🫡🫡🫡'), (55, '娜娜'), (66, 'Лукас'), (77, 'ルカス')
+----
+[source] INSERT 0 7
+[target] INSERT 0 7
+
+exec all
+INSERT INTO tbl2 VALUES (00, 'aaa'), (55, 'bb b'), (66, 'ééé'), (77, '🫡🫡🫡'), (88, '娜娜'), (1010, 'Лукас'), (1212, 'ルカス')
+----
+[source] INSERT 0 7
+[target] INSERT 0 7
+
+## Test that we can continue from data after file 1.
+# Force exception log.
+# Create multiple export files so we can continue from something other than part 1.
+fetch live notruncate expect-error suppress-error flush-rows=2
+----
+
+## Test without limit.
+list-tokens
+----
++--------------------------------------+--------------------------------------+-------------+-------------------+
+|                  ID                  |               FETCH ID               | TABLE NAME  |     FILE NAME     |
++--------------------------------------+--------------------------------------+-------------+-------------------+
+| 123e4567-e89b-12d3-a456-426655440000 | 123e4567-e89b-12d3-a456-426655440000 | public.tbl2 | part_00000001.csv |
+| 123e4567-e89b-12d3-a456-426655440000 | 123e4567-e89b-12d3-a456-426655440000 | public.tbl1 | part_00000001.csv |
++--------------------------------------+--------------------------------------+-------------+-------------------+
+Continuation Tokens.
+
+## Test with limit.
+list-tokens num-results=1
+----
++--------------------------------------+--------------------------------------+-------------+-------------------+
+|                  ID                  |               FETCH ID               | TABLE NAME  |     FILE NAME     |
++--------------------------------------+--------------------------------------+-------------+-------------------+
+| 123e4567-e89b-12d3-a456-426655440000 | 123e4567-e89b-12d3-a456-426655440000 | public.tbl2 | part_00000001.csv |
++--------------------------------------+--------------------------------------+-------------+-------------------+
+Continuation Tokens.
+
+## Test when no continuation tokens found.
+exec target
+TRUNCATE _molt_fetch_exception;
+----
+[target] TRUNCATE
+
+list-tokens num-results=1
+----
+No continuation tokens found.
+
+## Test when an error is forced.
+exec target
+DROP TABLE _molt_fetch_exception;
+----
+[target] DROP TABLE
+
+list-tokens expect-error num-results=1
+----
+ERROR: relation "_molt_fetch_exception" does not exist (SQLSTATE 42P01)

--- a/fetch/token.go
+++ b/fetch/token.go
@@ -1,0 +1,37 @@
+package fetch
+
+import (
+	"context"
+
+	"github.com/cockroachdb/molt/fetch/status"
+	"github.com/cockroachdb/molt/utils"
+	"github.com/jackc/pgx/v5"
+)
+
+func ListContinuationTokens(
+	ctx context.Context, testOnly bool, targetPgxConn *pgx.Conn, numResults int,
+) (string, error) {
+	exceptionLogs, err := status.GetAllExceptionLogs(ctx, targetPgxConn, numResults)
+	if err != nil {
+		return "", err
+	}
+
+	if len(exceptionLogs) == 0 {
+		return "No continuation tokens found.\n", nil
+	}
+
+	// Loop through the exception log results.
+	outputFormat := []utils.OutputFormat{}
+	for _, item := range exceptionLogs {
+		item.ID = utils.MaybeFormatID(testOnly, item.ID)
+		item.FetchID = utils.MaybeFormatID(testOnly, item.FetchID)
+		outputFormat = append(outputFormat, item)
+	}
+
+	tableStr, err := utils.BuildTable(outputFormat)
+	if err != nil {
+		return "", err
+	}
+
+	return tableStr, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,8 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0 // indirect
 	github.com/onsi/gomega v1.27.10 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
@@ -105,6 +107,7 @@ require (
 	github.com/prometheus/common v0.46.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/shirou/gopsutil v3.21.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
@@ -681,6 +683,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/oleiade/reflections v1.0.1/go.mod h1:rdFxbxq4QXVZWj0F+e9jqjDkc7dbp97vkRixKo2JR60=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -812,6 +816,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qq
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/utils/cli.go
+++ b/utils/cli.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/olekukonko/tablewriter"
+)
+
+type OutputFormat interface {
+	Caption() string
+	JSONFormat() string
+	TableFormat() []string
+	TableHeaders() []string
+}
+
+// BuildTable builds the table from the table header and structured
+// table data and returns a string that can be outputted to the command
+// or stdout.
+func BuildTable(of []OutputFormat) (string, error) {
+	tableOutput := &strings.Builder{}
+	table := tablewriter.NewWriter(tableOutput)
+
+	headers := []string{}
+	caption := ""
+
+	if len(of) > 0 {
+		headers = of[0].TableHeaders()
+		caption = of[0].Caption()
+	}
+	table.SetHeader(headers)
+	table.SetCaption(true, caption)
+	for _, item := range of {
+		if len(item.TableHeaders()) != len(item.TableFormat()) {
+			return "", errors.Newf("number of column headers %s doesn't match the number of data fields %s", item.TableHeaders(), item.TableFormat())
+		}
+
+		table.Append(item.TableFormat())
+	}
+	table.Render()
+
+	return tableOutput.String(), nil
+}
+
+func PrettyJSON(v any) string {
+	data, _ := json.MarshalIndent(v, "", "    ")
+	return string(data)
+}

--- a/utils/formatting.go
+++ b/utils/formatting.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/util/uuid"
 )
 
 func SchemaTableString(schema, table tree.Name) string {
@@ -54,4 +55,13 @@ func MaybeFormatFetchID(testOnly bool, s string) string {
 	}
 
 	return "0000000000"
+}
+
+// MaybeFormatID is to make a deterministic UUID for test.
+func MaybeFormatID(testOnly bool, s uuid.UUID) uuid.UUID {
+	if !testOnly {
+		return s
+	}
+
+	return uuid.Must(uuid.FromString("123e4567-e89b-12d3-a456-426655440000"))
 }


### PR DESCRIPTION
This feature will list out a tabular format for the continuation tokens active in the system. It will return tokens sorted based on the table name. Given that we only have one active set of tokens at a time, we do not need to do a join on the main status fetch table.

Resolves: CC-27319
Release Note: None

**Verify Test Only Mode Works**
```
+--------------------------------------+--------------------------------------+------------------+----------------------+
|                  ID                  |               FETCH ID               |    TABLE NAME    |      FILE NAME       |
+--------------------------------------+--------------------------------------+------------------+----------------------+
| 123e4567-e89b-12d3-a456-426655440000 | 123e4567-e89b-12d3-a456-426655440000 | public.employees | part_00000001.tar.gz |
+--------------------------------------+--------------------------------------+------------------+----------------------+
```

**Nominal**
```
+--------------------------------------+--------------------------------------+------------------+----------------------+
|                  ID                  |               FETCH ID               |    TABLE NAME    |      FILE NAME       |
+--------------------------------------+--------------------------------------+------------------+----------------------+
| 0f5ff49b-9765-403d-b40b-411fd98a2581 | c5f6c386-d117-4319-be26-9794622b013b | public.employees | part_00000001.tar.gz |
+--------------------------------------+--------------------------------------+------------------+----------------------+
```