### PR TITLE
fetch: unified continuation mode behavior so that specific token and multiple token behavior is the same

### DIFF
--- a/fetch/import_table.go
+++ b/fetch/import_table.go
@@ -183,7 +183,8 @@ func importTable(
 		file, err := importWithBisect(ctx, kvOptions, table, logger, conn, locBatch)
 		if err != nil {
 			fileName := status.ExtractFileNameFromErr(file)
-			pgErr := status.MaybeReportException(ctx, logger, baseConn.(*dbconn.PGConn).Conn, table.Name, err, fileName, status.StageDataLoad, isClearContinuationTokenMode, exceptionLog)
+			pgErr := status.MaybeReportException(ctx, logger, baseConn.(*dbconn.PGConn).Conn, table.Name, err, fileName,
+				status.StageDataLoad, isClearContinuationTokenMode, exceptionLog)
 			return ret, errors.Wrap(pgErr, "error importing data")
 		}
 

--- a/fetch/testdata/pg/continuation-edge-cases.ddt
+++ b/fetch/testdata/pg/continuation-edge-cases.ddt
@@ -230,7 +230,7 @@ table public.tbl1 not imported because no file name is present in the exception 
 exec target
 DELETE FROM _molt_fetch_exceptions WHERE table_name LIKE 'tbl%'
 ----
-[target] DELETE 0
+[target] DELETE 1
 
 query target
 SELECT fetch_id, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exceptions ORDER BY table_name DESC

--- a/fetch/testdata/pg/continuation.ddt
+++ b/fetch/testdata/pg/continuation.ddt
@@ -335,17 +335,17 @@ SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage F
 fetch_id	schema_name	table_name	message	sql_state	file_name	stage
 tag: SELECT 0
 
-# Ensure that we have a new fetch ID in the table.
+# Ensure that we do not have a new fetch ID in the table (still 2)
 query target
 SELECT COUNT(*) FROM _molt_fetch_status;
 ----
 [target]:
 count
-3
+2
 tag: SELECT 1
 
 ## Test that on error in continuation mode with only fetch-id
-## the token's fetch ID are now tied to a new one.
+## the token's fetch ID are still tied to the old one.
 # Insert an entry so that tbl2 is properly filled.
 exec target
 INSERT INTO _molt_fetch_exceptions (fetch_id, schema_name, table_name, file_name, sql_state, message, command, stage, time) VALUES ('d44762e5-6f70-43f8-8e15-58b4de10a007', 'public', 'tbl2', 'part_00000001.csv', '', 'duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists', '', '', now())
@@ -361,24 +361,31 @@ fetch_id	schema_name	table_name	message	sql_state	file_name	stage
 [212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl2	duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists		part_00000001.csv	
 tag: SELECT 1
 
-# Ensure that we see 1 item that has fetch_id of what we specified above.
+# Update the entry so we can continue from a known token we control.
+exec target
+UPDATE _molt_fetch_exceptions SET message = 'temp message' WHERE table_name LIKE 'tbl%'
+----
+[target] UPDATE 1
+
+# See the data before we run it.
 query target
-SELECT COUNT(*) FROM _molt_fetch_exceptions WHERE fetch_id='d44762e5-6f70-43f8-8e15-58b4de10a007';
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exceptions ORDER BY table_name DESC
 ----
 [target]:
-count
-1
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl2	temp message		part_00000001.csv	
 tag: SELECT 1
 
 fetch live expect-error notruncate cleanup-dir store-dir=continuation-test fetch-id=d44762e5-6f70-43f8-8e15-58b4de10a007
 ----
 ERROR: duplicate key value violates unique constraint "tbl2_pkey" (SQLSTATE 23505)
 
-# Note that we no longer have any exception log tokens that match the fetch_id.
+# Note that there is still only one entry with the same fetch ID.
+# Make sure that exception logs have the same IDs with updated messages.
 query target
-SELECT COUNT(*) FROM _molt_fetch_exceptions WHERE fetch_id='d44762e5-6f70-43f8-8e15-58b4de10a007';
+SELECT fetch_id, schema_name, table_name, message, sql_state, file_name, stage FROM _molt_fetch_exceptions ORDER BY table_name DESC
 ----
 [target]:
-count
-0
+fetch_id	schema_name	table_name	message	sql_state	file_name	stage
+[212 71 98 229 111 112 67 248 142 21 88 180 222 16 160 7]	public	tbl2	duplicate key value violates unique constraint "tbl2_pkey"; Key (id)=(0) already exists.	23505	part_00000001.csv	
 tag: SELECT 1


### PR DESCRIPTION

Previously, the multiple token and single-specific token case were treated differently, leading to potential continuation token loss when errors occur during non continuation logic. This means that we previously truncated the exceptions table before we even ran the import. Now, we unify the logic so that the behavior is as follows: if a table associated with a token fails, we update the associated entry with new information; if it succeeds, we remove the token. This happens within goroutines.

We also moved the connection cloning to the top of `fetchTable` so it can be used throughout the method.

Release Note: None