### PR TITLE
fetch: Add pagination for AWS ListObjects

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,9 +18,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Start Databases
+      - name: Start Dependencies
         working-directory: .github
-        run: docker-compose up -d cockroachdb cockroachdbtarget mysql postgresql
+        run: docker-compose up -d
 
       # Just cache based on job and go.sum contents.
       - name: Write cache key

--- a/fetch/datablobstorage/gcp.go
+++ b/fetch/datablobstorage/gcp.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cockroachdb/molt/dbtable"
 	"github.com/cockroachdb/molt/testutils"
 	"github.com/cockroachdb/molt/utils"
-	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"github.com/rs/zerolog"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
@@ -128,11 +127,11 @@ func (s *gcpStore) ListFromContinuationPoint(
 	ctx context.Context, table dbtable.VerifiedTable, fileName string,
 ) ([]Resource, error) {
 	key, prefix := getKeyAndPrefix(fileName, s.bucketPath, table)
-	return listFromContinuationPointGCP(ctx, stiface.AdaptClient(s.client), key, prefix, s.bucket, s)
+	return listFromContinuationPointGCP(ctx, s.client, key, prefix, s.bucket, s)
 }
 
 func listFromContinuationPointGCP(
-	ctx context.Context, client stiface.Client, key, prefix, bucket string, gcpStore *gcpStore,
+	ctx context.Context, client *storage.Client, key, prefix, bucket string, gcpStore *gcpStore,
 ) ([]Resource, error) {
 	it := client.Bucket(bucket).Objects(ctx, &storage.Query{
 		Prefix: prefix,
@@ -144,6 +143,7 @@ func listFromContinuationPointGCP(
 	})
 
 	resources := []Resource{}
+	// GCP's iterator paginates by default so no need to handle here
 	for {
 		if attrs, err := it.Next(); err != nil {
 			if err == iterator.Done {

--- a/fetch/datablobstorage/gcp_integration_test.go
+++ b/fetch/datablobstorage/gcp_integration_test.go
@@ -1,0 +1,49 @@
+package datablobstorage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+func TestListFromContinuationPointGCP(t *testing.T) {
+	ctx := context.Background()
+	var sb strings.Builder
+	gcpClient, err := storage.NewClient(ctx,
+		option.WithEndpoint("http://localhost:4443/storage/v1/"),
+		option.WithoutAuthentication(),
+	)
+
+	require.NoError(t, err)
+
+	gcpStore := gcpStore{
+		bucket: "fetch-test",
+		logger: zerolog.New(&sb),
+	}
+
+	// Create the test bucket
+	err = gcpClient.Bucket("fetch-test").Create(ctx, "", nil)
+	require.NoError(t, err)
+
+	// Seed the initial data with 8 files
+	for i := 1; i <= 8; i++ {
+		o := gcpClient.Bucket("fetch-test").Object(fmt.Sprintf("public.inventory/part_0000000%d.tar.gz", i))
+		wc := o.NewWriter(ctx)
+		_, err = io.Copy(wc, bytes.NewReader([]byte("abcde")))
+		require.NoError(t, err)
+		require.NoError(t, wc.Close())
+	}
+
+	// List from file 4 which should result in files 4-8 inclusive
+	resources, err := listFromContinuationPointGCP(ctx, gcpClient, "public.inventory/part_00000004.tar.gz", "public.inventory", "fetch-test", &gcpStore)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(resources))
+}

--- a/fetch/datablobstorage/gcp_test.go
+++ b/fetch/datablobstorage/gcp_test.go
@@ -1,13 +1,8 @@
 package datablobstorage
 
 import (
-	"context"
-	"strings"
 	"testing"
 
-	"cloud.google.com/go/storage"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/google"
 )
@@ -38,67 +33,4 @@ func TestGCPResource_ImportURL(t *testing.T) {
 			require.Equal(t, tc.expected, u)
 		})
 	}
-}
-
-func TestListFromContinuationPointGCP(t *testing.T) {
-	t.Run("number of rows is specified leads to correct number of resources", func(t *testing.T) {
-		// Set up the mock expected return
-		gcpClient := &gcpClientMock{}
-		bucketMock := &gcpBucketMock{}
-		ctx := context.Background()
-		gcpClient.On("Bucket", mock.Anything).Return(bucketMock)
-		bucketMock.On("Objects", ctx, mock.Anything).
-			Return(&gcpObjectITMock{
-				i: 0,
-				next: []storage.ObjectAttrs{
-					{Name: "part_00000004.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
-					{Name: "part_00000005.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
-					{Name: "part_00000006.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
-					{Name: "part_00000007.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
-					{Name: "part_00000008.tar.gz", Metadata: map[string]string{numRowsKeyGCP: "10"}},
-				},
-			})
-
-		gcpStore := gcpStore{
-			bucket: "fetch-test",
-			creds: &google.Credentials{
-				JSON: []byte(`{"a":b}`),
-			},
-		}
-		resources, err := listFromContinuationPointGCP(ctx, gcpClient, "part_00000004.tar.gz", "public.inventory", gcpStore.bucket, nil /* gcpStore */)
-		require.NoError(t, err)
-		require.Len(t, resources, 5)
-	})
-
-	t.Run("number of rows not specified leads to correct number of resources", func(t *testing.T) {
-		// Set up the mock expected return
-		gcpClient := &gcpClientMock{}
-		bucketMock := &gcpBucketMock{}
-		ctx := context.Background()
-		var sb strings.Builder
-		gcpClient.On("Bucket", mock.Anything).Return(bucketMock)
-		bucketMock.On("Objects", ctx, mock.Anything).
-			Return(&gcpObjectITMock{
-				i: 0,
-				next: []storage.ObjectAttrs{
-					{Name: "part_00000004.tar.gz", Metadata: map[string]string{}},
-					{Name: "part_00000005.tar.gz", Metadata: map[string]string{}},
-					{Name: "part_00000006.tar.gz", Metadata: map[string]string{}},
-					{Name: "part_00000007.tar.gz", Metadata: map[string]string{}},
-					{Name: "part_00000008.tar.gz", Metadata: map[string]string{}},
-				},
-			})
-
-		gcpStore := gcpStore{
-			bucket: "fetch-test",
-			creds: &google.Credentials{
-				JSON: []byte(`{"a":b}`),
-			},
-			logger: zerolog.New(&sb),
-		}
-		resources, err := listFromContinuationPointGCP(ctx, gcpClient, "part_00000004.tar.gz", "public.inventory", gcpStore.bucket, &gcpStore /* gcpStore */)
-		require.NoError(t, err)
-		require.Len(t, resources, 5)
-		require.Contains(t, sb.String(), "failed to find metadata")
-	})
 }

--- a/fetch/datablobstorage/gcp_testutil.go
+++ b/fetch/datablobstorage/gcp_testutil.go
@@ -1,49 +1,9 @@
 package datablobstorage
 
 import (
-	"context"
-
 	"cloud.google.com/go/storage"
 	"github.com/cockroachdb/errors"
-	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
-	"github.com/stretchr/testify/mock"
-	"google.golang.org/api/iterator"
 )
-
-type gcpClientMock struct {
-	stiface.Client
-	mock.Mock
-}
-type gcpBucketMock struct {
-	stiface.BucketHandle
-	mock.Mock
-}
-type gcpObjectITMock struct {
-	stiface.ObjectIterator
-	i    int
-	next []storage.ObjectAttrs
-}
-
-func (m *gcpClientMock) Bucket(name string) stiface.BucketHandle {
-	args := m.Called(name)
-	return args.Get(0).(*gcpBucketMock)
-}
-
-func (m *gcpBucketMock) Objects(ctx context.Context, q *storage.Query) (it stiface.ObjectIterator) {
-	args := m.Called(ctx, q)
-	return args.Get(0).(*gcpObjectITMock)
-}
-
-func (it *gcpObjectITMock) Next() (a *storage.ObjectAttrs, err error) {
-	if it.i == len(it.next) {
-		err = iterator.Done
-		return
-	}
-
-	a = &it.next[it.i]
-	it.i += 1
-	return
-}
 
 // GCPStorageWriterMock is to mock a gcp storage that always fail to upload to
 // the bucket. We use it to simulate a disastrous edge case and ensure that

--- a/fetch/datablobstorage/s3_integration_test.go
+++ b/fetch/datablobstorage/s3_integration_test.go
@@ -1,0 +1,96 @@
+package datablobstorage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListFromContinuationPointAWS(t *testing.T) {
+	ctx := context.Background()
+	var sb strings.Builder
+	sess, err := session.NewSession(&aws.Config{
+		Credentials:      credentials.NewStaticCredentials("test", "test", ""),
+		S3ForcePathStyle: aws.Bool(true),
+		Endpoint:         aws.String("http://s3.localhost.localstack.cloud:4566"),
+		Region:           aws.String("us-east-1"),
+	})
+	require.NoError(t, err)
+	s3Cli := s3.New(sess)
+
+	s3Store := s3Store{
+		bucket: "fetch-test",
+		logger: zerolog.New(&sb),
+	}
+
+	// Create the test bucket
+	_, err = s3Cli.CreateBucketWithContext(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String("fetch-test"),
+	})
+	require.NoError(t, err)
+
+	// Seed the initial data with 8 files
+	for i := 1; i <= 8; i++ {
+		_, err := s3Cli.PutObjectWithContext(ctx, &s3.PutObjectInput{
+			Key:      aws.String(fmt.Sprintf("public.inventory/part_0000000%d.tar.gz", i)),
+			Body:     bytes.NewReader([]byte("abcde")),
+			Bucket:   aws.String("fetch-test"),
+			Metadata: map[string]*string{numRowKeysAWS: aws.String("5")},
+		})
+		require.NoError(t, err)
+	}
+
+	// List from file 4 which should result in files 4-8 inclusive
+	resources, err := listFromContinuationPointAWS(ctx, s3Cli, "public.inventory/part_00000004.tar.gz", "public.inventory", &s3Store, 10)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(resources))
+}
+
+func TestListFromContinuationPointAWSPagination(t *testing.T) {
+	ctx := context.Background()
+	var sb strings.Builder
+	sess, err := session.NewSession(&aws.Config{
+		Credentials:      credentials.NewStaticCredentials("test", "test", ""),
+		S3ForcePathStyle: aws.Bool(true),
+		Endpoint:         aws.String("http://s3.localhost.localstack.cloud:4566"),
+		Region:           aws.String("us-east-1"),
+	})
+	require.NoError(t, err)
+	s3Cli := s3.New(sess)
+
+	s3Store := s3Store{
+		bucket: "fetch-test-paginate",
+		logger: zerolog.New(&sb),
+	}
+
+	// Create the test bucket
+	_, err = s3Cli.CreateBucketWithContext(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String("fetch-test-paginate"),
+	})
+	require.NoError(t, err)
+
+	// Seed the initial data with 20 files
+	for i := 1; i <= 20; i++ {
+		_, err := s3Cli.PutObjectWithContext(ctx, &s3.PutObjectInput{
+			Key:      aws.String(fmt.Sprintf("public.inventory/part_%08d.tar.gz", i)),
+			Body:     bytes.NewReader([]byte("abcde")),
+			Bucket:   aws.String("fetch-test-paginate"),
+			Metadata: map[string]*string{numRowKeysAWS: aws.String("5")},
+		})
+		require.NoError(t, err)
+	}
+
+	// List from file 13 and ensure pagination worked as expected
+	resources, err := listFromContinuationPointAWS(ctx, s3Cli, "public.inventory/part_00000013.tar.gz", "public.inventory", &s3Store, 5)
+	require.NoError(t, err)
+	require.Equal(t, 8, len(resources))
+}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -514,7 +514,7 @@ func fetchTable(
 					}
 				}()
 
-				r, err := importTable(ctx, cfg, targetConn, logger, table.VerifiedTable, e.Resources, testingKnobs, isLocal, isClearContinuationTokenMode, exceptionLog)
+				r, err := importTable(ctx, cfg, targetConn, logger, table.VerifiedTable, e.Resources, isLocal, isClearContinuationTokenMode, exceptionLog)
 				if err != nil {
 					return err
 				}

--- a/fetch/import_table.go
+++ b/fetch/import_table.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/molt/fetch/status"
 	"github.com/cockroachdb/molt/moltlogger"
 	"github.com/cockroachdb/molt/retry"
-	"github.com/cockroachdb/molt/testutils"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rs/zerolog"
@@ -136,7 +135,6 @@ func importTable(
 	logger zerolog.Logger,
 	table dbtable.VerifiedTable,
 	resources []datablobstorage.Resource,
-	testingKnobs testutils.FetchTestingKnobs,
 	isLocal bool,
 	isClearContinuationTokenMode bool,
 	exceptionLog *status.ExceptionLog,

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/cockroachdb/datadriven v1.0.3-0.20230801171734-e384cf455877
 	github.com/cockroachdb/errors v1.9.1
 	github.com/go-sql-driver/mysql v1.7.2-0.20230527164328-99976f4f587d
-	github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720
 	github.com/jackc/pgx/v5 v5.5.1
 	github.com/jstemmer/go-junit-report v1.0.0
 	github.com/lib/pq v1.10.6
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pashagolub/pgxmock/v3 v3.3.0
 	github.com/pingcap/tidb v1.1.0-beta.0.20211124132551-4a1b2e9fe5b5
 	github.com/pingcap/tidb/parser v0.0.0-20211124132551-4a1b2e9fe5b5
@@ -90,7 +90,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0 // indirect
 	github.com/onsi/gomega v1.27.10 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,7 +3,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
-cloud.google.com/go v0.44.3/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
@@ -463,8 +462,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
-github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720 h1:zC34cGQu69FG7qzJ3WiKW244WfhDC3xxYMeNOX2gtUQ=
-github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
@@ -631,7 +628,6 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -814,7 +810,6 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
This commit adds pagination support for ListFromContinuationPoint for the AWS case. Previously we would cap out at 1000 items. But, if the item you wanted was after 1000, it wouldnt return.

Release note: None