### PR TITLE
fetch/export: fix bug when source connection failed to establish

### DIFF
--- a/fetch/export_table.go
+++ b/fetch/export_table.go
@@ -64,8 +64,11 @@ func exportTable(
 	copyWG, _ := errgroup.WithContext(ctx)
 	copyWG.Go(func() error {
 		sqlSrcConn, err := sqlSrc.Conn(ctx)
+		if testingKnobs.FailedEstablishSrcConnForExport {
+			err = errors.Newf("forced error when establishing conn for export")
+		}
 		if err != nil {
-			return err
+			return sqlWrite.CloseWithError(err)
 		}
 		return errors.CombineErrors(
 			func() error {

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -162,6 +162,7 @@ func TestDataDriven(t *testing.T) {
 						direct := false
 						compress := false
 						corruptCSVFile := false
+						failedEstablishConnForExport := false
 						fetchId := ""
 						passedInDir := ""
 						cleanup := false
@@ -186,6 +187,8 @@ func TestDataDriven(t *testing.T) {
 								compress = true
 							case "corrupt-csv":
 								corruptCSVFile = true
+							case "failed-conn-export":
+								failedEstablishConnForExport = true
 							case "fetch-id":
 								fetchId = cmd.Vals[0]
 							case "store-dir":
@@ -279,6 +282,9 @@ func TestDataDriven(t *testing.T) {
 						knobs := testutils.FetchTestingKnobs{}
 						if corruptCSVFile {
 							knobs.TriggerCorruptCSVFile = true
+						}
+						if failedEstablishConnForExport {
+							knobs.FailedEstablishSrcConnForExport = true
 						}
 
 						err = Fetch(

--- a/fetch/testdata/pg/failed-export.ddt
+++ b/fetch/testdata/pg/failed-export.ddt
@@ -1,0 +1,24 @@
+exec all
+CREATE TABLE foo(a INT PRIMARY KEY);
+----
+[source] CREATE TABLE
+[target] CREATE TABLE
+
+exec source
+INSERT INTO foo (a) SELECT * FROM generate_series(1, 2000);
+----
+[source] INSERT 0 2000
+
+exec source
+ALTER TABLE foo ADD COLUMN b TEXT DEFAULT repeat('Lorem ipsum dolor sit amet, consectetur adipiscing elit. ', 9000);
+----
+[source] ALTER TABLE
+
+exec target
+ALTER TABLE foo ADD COLUMN b TEXT;
+----
+[target] ALTER TABLE
+
+fetch shards=2 failed-conn-export expect-error
+----
+forced error when establishing conn for export

--- a/testutils/knobs.go
+++ b/testutils/knobs.go
@@ -5,6 +5,8 @@ type FetchTestingKnobs struct {
 	TriggerCorruptCSVFile bool
 
 	FailedWriteToBucket FailedWriteToBucketKnob
+
+	FailedEstablishSrcConnForExport bool
 }
 
 type FailedWriteToBucketKnob struct {


### PR DESCRIPTION
Previously, when the connection for the datasource failed to be established during export, the sql writer is not closed, causing the process hangs at `record, err := r.Read()`, as it is reading from a dead but not closed pipe. This PR is to fix it, with test added. 

Release note (bug fix): during export, if the source connection fails to establish, without closing the sqlwriter will cause the whole program to hang. We fixed it by properly closing the sqlwriter. 

jira: [CC-27433](https://cockroachlabs.atlassian.net/browse/CC-27433)