### PR TITLE
[CC-27525] fetch: Set copy session vars

### DIFF
--- a/fetch/copy.go
+++ b/fetch/copy.go
@@ -41,13 +41,15 @@ func Copy(
 	}()
 
 	dataLogger := moltlogger.GetDataLogger(logger)
-	ret := CopyResult{
-		StartTime: time.Now(),
-	}
+	var ret CopyResult
 
 	rowsSoFar := 0
 	conn := baseConn.(*dbconn.PGConn).Conn
-
+	// Set the session variables required for COPY
+	if err := datablobstorage.SetCopyEnvVars(ctx, conn); err != nil {
+		return ret, err
+	}
+	ret.StartTime = time.Now()
 	for i, resource := range resources {
 		key, err := resource.Key()
 		if err != nil {

--- a/fetch/datablobstorage/copy_direct.go
+++ b/fetch/datablobstorage/copy_direct.go
@@ -41,6 +41,12 @@ func (c *copyCRDBDirect) CreateFromReader(
 	if err != nil {
 		return nil, err
 	}
+
+	// Set the session variables required for COPY
+	if err := SetCopyEnvVars(ctx, conn); err != nil {
+		return nil, err
+	}
+
 	if testingKnobs.FailedWriteToBucket.FailedBeforeReadFromPipe {
 		return nil, errors.New(DirectCopyWriterMockErrMsg)
 	}

--- a/fetch/datablobstorage/datablobstorage.go
+++ b/fetch/datablobstorage/datablobstorage.go
@@ -159,3 +159,13 @@ func GenerateDatastore(
 
 	return src, err
 }
+
+func SetCopyEnvVars(ctx context.Context, conn *pgx.Conn) error {
+	if _, err := conn.Exec(ctx, "SET copy_from_retries_enabled = true"); err != nil {
+		return err
+	}
+	if _, err := conn.Exec(ctx, "SET copy_from_atomic_enabled = false"); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This commit sets the 2 copy session variables required for larger copy operations. These are the same ones we currently have to set for DMS to succeed.

Release Note: None