### PR TITLE
fix: dropped column causes verify error exit

### DIFF
--- a/verify/tableverify/query.go
+++ b/verify/tableverify/query.go
@@ -44,7 +44,7 @@ WHERE pg_database.datname = pg_catalog.current_database()`,
 attname, atttypid, attnotnull, collname
 FROM pg_attribute
 LEFT OUTER JOIN pg_collation ON (pg_collation.oid = pg_attribute.attcollation)
-WHERE attrelid = $1 AND attnum > 0
+WHERE attrelid = $1 AND attnum > 0 AND attisdropped is false
 ORDER BY attnum`,
 			table.OID,
 		)


### PR DESCRIPTION
The GetColumns function is only used via `verify/tableverify/query` and there doesn't appear to be any value to getting columns that have been dropped. Thus we're suggesting that we only consider columns where `attisdropped is false`.

This fixes [Issue 187](https://github.com/cockroachdb/molt/issues/187)

Tested using the same methodology described in the [Issue](https://github.com/cockroachdb/molt/issues/187#issuecomment-2013699422)