### PR TITLE
verfiy: ignore dropped columns

### DIFF
--- a/verify/tableverify/query.go
+++ b/verify/tableverify/query.go
@@ -44,7 +44,7 @@ WHERE pg_database.datname = pg_catalog.current_database()`,
 attname, atttypid, attnotnull, collname
 FROM pg_attribute
 LEFT OUTER JOIN pg_collation ON (pg_collation.oid = pg_attribute.attcollation)
-WHERE attrelid = $1 AND attnum > 0
+WHERE attrelid = $1 AND attnum > 0 AND attisdropped = false
 ORDER BY attnum`,
 			table.OID,
 		)

--- a/verify/testdata/datadriven/crdb/dropped_column.ddt
+++ b/verify/testdata/datadriven/crdb/dropped_column.ddt
@@ -1,0 +1,24 @@
+# Test that a dropped column can result in a successful fetch
+
+exec all
+CREATE TABLE t_drop (i1 INT4 NOT NULL, i2 INT4 NOT NULL, t TEXT NOT NULL, CONSTRAINT pkey PRIMARY KEY (i2, i1))
+----
+[crdb] CREATE TABLE
+[crdb] CREATE TABLE
+
+exec all
+ALTER TABLE t_drop DROP COLUMN t
+----
+[crdb] ALTER TABLE
+[crdb] ALTER TABLE
+
+verify
+----
+{"level":"info","message":"starting verify on public.t_drop, shard 1/1"}
+{"level":"info","type":"summary","table_schema":"public","table_name":"t_drop","num_truth_rows":0,"num_success":0,"num_conditional_success":0,"num_missing":0,"num_mismatch":0,"num_extraneous":0,"num_live_retry":0,"num_column_mismatch":0,"message":"finished row verification on public.t_drop (shard 1/1)"}
+
+exec all
+DROP TABLE t_drop
+----
+[crdb] DROP TABLE
+[crdb] DROP TABLE

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -84,6 +84,19 @@ func TestDataDrivenMySQL(t *testing.T) {
 	)
 }
 
+func TestDataDrivenCRDB(t *testing.T) {
+	datadriven.Walk(
+		t,
+		"testdata/datadriven/crdb",
+		func(t *testing.T, path string) {
+			testDataDriven(t, path, []connArg{
+				{id: "crdb", connStr: testutils.CRDBConnStr()},
+				{id: "crdb", connStr: testutils.CRDBTargetConnStr()},
+			})
+		},
+	)
+}
+
 func testDataDriven(t *testing.T, path string, connArgs []connArg) {
 	ctx := context.Background()
 


### PR DESCRIPTION
This commit adds a attisdropped clause for pg/crdb queries when getting columnns to verify. Previously, this would return and when running LoadDataType in the PGX driver, it would cause an issue as the dropped column could not be resolved. We now omit dropped columns from being returned since we are not verifying them anyways.

Release Note: Fixes a bug for pg/crdb verify that causes an error when there are dropped columns on the table
Fixes: #187