### PR TITLE
scripts: added setups script for scale testing

### DIFF
--- a/build/teamcity/internal/molt/molt-nightly.sh
+++ b/build/teamcity/internal/molt/molt-nightly.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+set -m
+
+# Get this current directory.
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Run the setup script.
+$DIR/setup-scale-test.sh -n 4 -z us-east-1a

--- a/build/teamcity/internal/molt/setup-scale-test.sh
+++ b/build/teamcity/internal/molt/setup-scale-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+set -m
+
+export ROACHPROD_USER=migrations
+# Read flags
+CLUSTER=migrations-nightly-final
+PROVIDER="aws"
+ZONE="us-east-1a"
+NUM_NODES=4
+
+# TODO instance size and settings.
+while getopts c:p:z:n: flag
+do
+    case "${flag}" in
+        c) CLUSTER=${OPTARG};;
+        p) PROVIDER=${OPTARG};;
+        z) ZONE=${OPTARG};;
+        n) NUM_NODES=${OPTARG};;
+    esac
+done
+
+export CLUSTER
+
+echo "Listing out all parameters"
+echo "Cloud Provider: $PROVIDER";
+echo "Zone: $ZONE";
+echo "Num Nodes: $NUM_NODES";
+echo "Cluster: $CLUSTER";
+
+# Setup Auth
+echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
+gcloud auth activate-service-account --key-file=creds.json
+
+aws configure set aws_access_key_id %env.AWS_ACCESS_KEY_ID%;
+aws configure set aws_secret_access_key %env.AWS_SECRET_ACCESS_KEY%;
+aws configure set default.region "US-EAST-1";
+mkdir -p ~/.ssh/
+
+ssh-keygen -t rsa -q -f "$HOME/.ssh/id_rsa" -N ""
+ls ~/.ssh/
+# Download Roachprod Binary
+gcloud storage cp gs://migrations-fetch-ci-test/roachprod-binary/roachprod roachprod
+
+# TODO: Build the binary for MOLT
+# go build -o ./molt .
+
+# Download the latest MOLT image for now.
+wget https://molt.cockroachdb.com/molt/cli/molt-latest.linux-amd64.tgz
+tar -xvzf "molt-latest.linux-amd64.tgz"
+
+# We want to clean up the cluster and roachprod binary.
+trap "./roachprod destroy $CLUSTER && rm roachprod" EXIT
+
+# Setup Roachprod
+chmod +x roachprod
+
+# Conditional logic for AWS vs. GCE.
+if [[ "$PROVIDER" == "aws" ]]; then
+    ./roachprod create $CLUSTER --clouds $PROVIDER --aws-zones $ZONE -n $NUM_NODES
+elif [[ "$PROVIDER" == "gcp" ]]; then
+    ./roachprod create $CLUSTER --clouds $PROVIDER --gce-zones $ZONE -n $NUM_NODES
+fi
+
+./roachprod stage $CLUSTER release v23.2.2 --os linux
+./roachprod start $CLUSTER
+
+# Put binary on
+./roachprod put $CLUSTER molt
+
+exit 0


### PR DESCRIPTION
This setup script makes the different setup parameterized so people can customize the cluster, names, sizes, and number of nodes, etc.

Release Note: None

Testing:
- Happy path: https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593335?buildTab=log&focusLine=1426&logView=linear&linesState=510
- Simulating failure: https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=548&linesState=513
```
[23:30:33 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1433&linesState=1433)  + ./roachpad stage migrations-nightly-final release v23.2.2 --os linux
[23:30:33 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1434&linesState=1434)  /home/agent/work/f8635fededb8e978/build/teamcity/internal/molt/setup-scale-test.sh: line 65: ./roachpad: No such file or directory
[23:30:33 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1435&linesState=1435)  + ./roachprod destroy migrations-nightly-final
[23:30:39 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1436&linesState=1436)  23:30:39 roachprod.go:1345: Destroying cluster migrations-nightly-final with 4 nodes
[23:30:41 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1437&linesState=1437)  23:30:41 roachprod.go:1333: OK
[23:30:41 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1438&linesState=1438)  + rm roachprod
[23:30:41 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1439&linesState=1439)  Docker event: {"status":"die","id":"e10239de1f6c5b0eec4f8ff7a4f80c554f7ea78aa7e9d4a474da53f1d5253be1","from":"us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20240202-060306","Type":"container","Action":"die","Actor":{"ID":"e10239de1f6c5b0eec4f8ff7a4f80c554f7ea78aa7e9d4a474da53f1d5253be1","Attributes":{"execDuration":"88","exitCode":"127","image":"us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20240202-060306","jetbrains.teamcity.buildId":"14593342","name":"wonderful_nash","org.opencontainers.image.ref.name":"ubuntu","org.opencontainers.image.version":"20.04"}},"scope":"local","time":1711582241,"timeNano":1711582241230596783}
[23:30:41 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1440&linesState=1440)  Docker event: {"status":"destroy","id":"e10239de1f6c5b0eec4f8ff7a4f80c554f7ea78aa7e9d4a474da53f1d5253be1","from":"us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20240202-060306","Type":"container","Action":"destroy","Actor":{"ID":"e10239de1f6c5b0eec4f8ff7a4f80c554f7ea78aa7e9d4a474da53f1d5253be1","Attributes":{"image":"us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20240202-060306","jetbrains.teamcity.buildId":"14593342","name":"wonderful_nash","org.opencontainers.image.ref.name":"ubuntu","org.opencontainers.image.version":"20.04"}},"scope":"local","time":1711582241,"timeNano":1711582241241261535}
[23:30:41 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1441&linesState=1441)  Process exited with code 127
[23:30:41 ](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Molt_MoltNightly/14593342?buildTab=log&logFilter=debug&logView=linear&focusLine=1443&linesState=1443)  Process exited with code 127 (Step: Run nightly (Command Line))
```